### PR TITLE
Change WebAppCloudfrontUrl stack output name to

### DIFF
--- a/IMPLEMENTATION_GUIDE.md
+++ b/IMPLEMENTATION_GUIDE.md
@@ -70,7 +70,7 @@ This assumes that MIE has been full deployed at this point.
 
 ## 5.1. Logging in to the Application
 1. Navigate to the CloudFormation console where you launched MIE.
-1. From the **Outputs** tab of your stack, copy the value of `WebAppCloudfrontUrl` on to your browser. This should open up the sample application.
+1. From the **Outputs** tab of your stack, copy the value of `MediaInsightsWebAppUrl` on to your browser. This should open up the sample application.
 1. On the login page, enter the email address you provided in the **AdminEmail** for username. Enter the **temporary password** you were emailed in the password. 
 1. Enter a new password when prompted to update the temporary one. Save this off somewhere handy in case you have to login back to the sample application. 
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ After the stack successfully deploys, you can find important interface resources
 
 **MediaInsightsEnginePython37Layer** is a lambda layer required to build new operator lambdas
 
-**WebAppCloudfrontUrl** is the Url for the sample Media Insights web application
+**MediaInsightsWebAppUrl** is the Url for the sample Media Insights web application
 
 **WorkflowApiEndpoint** is the endpoint for accessing the Workflow APIs to create, update, delete and execute MIE workflows.
 

--- a/deployment/media-insights-stack.yaml
+++ b/deployment/media-insights-stack.yaml
@@ -1445,10 +1445,10 @@ Outputs:
     Value: !GetAtt MediaInsightsWorkflowApi.Outputs.EndpointURL
     Export:
       Name: !Join [":", [!Ref "AWS::StackName", WorkflowApiEndpoint]]
-  WebAppCloudfrontUrl:
+  MediaInsightsWebAppUrl:
     Condition: DeployDemoSiteCondition
-    Description: Url of the MIE Webapp
-    Value: !GetAtt MediaInsightsWebApp.Outputs.CloudfrontUrl
+    Description: Url of the Media Insights Engine sample web application
+    Value: !Join ["", ["https://", !GetAtt MediaInsightsWebApp.Outputs.CloudfrontUrl]]
   ElasticsearchEndpoint:
     Condition: DeployAnalyticsPipelineCondition
     Description: Endpoint for elasticsearch cluster


### PR DESCRIPTION
MediaInsightsWebAppUrl and make the value a clickable link

*Issue #, if available:*
#46 

*Description of changes:*
Renamed WebAppCloudfrontUrl stack output to MediaInsightsWebAppUrl and made the value a clickable link

Tested by building, deploying and testing the link.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
