### PR TITLE
Regionless templates and misc small bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ MIE is a framework to accelerate the development of serverless applications that
 
 MIE includes a demo GUI for video content analysis and search. The [Implementation Guide](https://github.com/awslabs/aws-media-insights-engine/blob/master/IMPLEMENTATION_GUIDE.md) explains how to build other applications with MIE. 
 
-***NOTE:*** *Some of the services used by MIE are not in the AWS free tier. Assume you will pay money when you run videos through MIE.*
-
 # Installation
 You can deploy MIE and the demo GUI in your AWS account with the following one-click deploy buttons:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MIE is a framework to accelerate the development of serverless applications that
 
 MIE includes a demo GUI for video content analysis and search. The [Implementation Guide](https://github.com/awslabs/aws-media-insights-engine/blob/master/IMPLEMENTATION_GUIDE.md) explains how to build other applications with MIE. 
 
-***NOTE:*** *Some of the services used by MIE are not in the AWS free tier. Assume you will pay money when you run videos through MIE. It can get expensive to process videos longer than a few minutes.*
+***NOTE:*** *Some of the services used by MIE are not in the AWS free tier. Assume you will pay money when you run videos through MIE.*
 
 # Installation
 You can deploy MIE and the demo GUI in your AWS account with the following one-click deploy buttons:

--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -645,24 +645,24 @@ echo "Copying the prepared distribution to S3..."
 for file in "$dist_dir"/*.zip
 do
   if [ -n "$profile" ]; then
-    aws s3 cp "$file" s3://"$bucket"/media-insights-solution/"$version"/code/ --profile "$profile"
+    aws s3 cp "$file" s3://"$bucket"-"$region"/media-insights-solution/"$version"/code/ --profile "$profile"
   else
-    aws s3 cp "$file" s3://"$bucket"/media-insights-solution/"$version"/code/
+    aws s3 cp "$file" s3://"$bucket"-"$region"/media-insights-solution/"$version"/code/
   fi
 done
 for file in "$dist_dir"/*.template
 do
   if [ -n "$profile" ]; then
-    aws s3 cp "$file" s3://"$bucket"/media-insights-solution/"$version"/cf/ --profile "$profile"
+    aws s3 cp "$file" s3://"$bucket"-"$region"/media-insights-solution/"$version"/cf/ --profile "$profile"
   else
-    aws s3 cp "$file" s3://"$bucket"/media-insights-solution/"$version"/cf/
+    aws s3 cp "$file" s3://"$bucket"-"$region"/media-insights-solution/"$version"/cf/
   fi
 done
 echo "Uploading the MIE web app..."
 if [ -n "$profile" ]; then
-  aws s3 cp "$webapp_dir"/dist s3://"$bucket"/media-insights-solution/"$version"/code/website --recursive --profile "$profile"
+  aws s3 cp "$webapp_dir"/dist s3://"$bucket"-"$region"/media-insights-solution/"$version"/code/website --recursive --profile "$profile"
 else
-  aws s3 cp "$webapp_dir"/dist s3://"$bucket"/media-insights-solution/"$version"/code/website --recursive
+  aws s3 cp "$webapp_dir"/dist s3://"$bucket"-"$region"/media-insights-solution/"$version"/code/website --recursive
 fi
 
 echo "------------------------------------------------------------------------------"

--- a/deployment/media-insights-dataplane-streaming-stack.template
+++ b/deployment/media-insights-dataplane-streaming-stack.template
@@ -24,7 +24,7 @@ Parameters:
   MieAdminRole:
     Type: String
 
-Mappings: 
+Mappings:
   SourceCode:
         General:
             S3Bucket: '%%BUCKET_NAME%%'
@@ -53,7 +53,7 @@ Resources:
       Handler: "stream.lambda_handler"
       Role: !GetAtt LambdaStreamRole.Arn
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -131,7 +131,7 @@ Resources:
           "/",
           [
             "https://s3.amazonaws.com",
-            !FindInMap ["SourceCode", "General", "S3Bucket"],
+            !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]],
             !FindInMap ["SourceCode", "General", "TemplateKeyPrefix"],
             "media-insights-elasticsearch.template",
           ],

--- a/deployment/media-insights-stack.yaml
+++ b/deployment/media-insights-stack.yaml
@@ -77,7 +77,7 @@ Parameters:
   MaxConcurrentWorkflows:
     Type: Number
     Description: Maximum number of workflows to run concurrently.  When the maximum is reached, additional workflows are added to a wait queue.
-    Default: 10
+    Default: 5
     MinValue: 1
   #  TranscriberApp:
   #    Type: String
@@ -929,7 +929,7 @@ Resources:
       CompatibleRuntimes:
         - python3.7
       Content:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -949,7 +949,7 @@ Resources:
       CompatibleRuntimes:
         - python3.7
       Content:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1006,7 +1006,7 @@ Resources:
           DEFAULT_MAX_CONCURRENT_WORKFLOWS: !Ref MaxConcurrentWorkflows
       Handler: app.workflow_scheduler_lambda
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1049,7 +1049,7 @@ Resources:
               - Arn
       Handler: app.complete_stage_execution_lambda
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1079,7 +1079,7 @@ Resources:
           WORKFLOW_TABLE_NAME: !Ref WorkflowTable
       Handler: app.filter_operation_lambda
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1105,7 +1105,7 @@ Resources:
         - !Ref "MediaInsightsEnginePython37Layer"
       Role: !GetAtt "operatorFailedRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1126,7 +1126,7 @@ Resources:
           "/",
           [
             "https://s3.amazonaws.com",
-            !FindInMap ["SourceCode", "General", "S3Bucket"],
+            !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]],
             !FindInMap ["SourceCode", "General", "TemplateKeyPrefix"],
             "media-insights-dataplane-api-stack.template",
           ],
@@ -1135,7 +1135,7 @@ Resources:
         DataplaneTableName: !Ref DataplaneTable
         DataplaneBucketName: !Ref Dataplane
         UserPoolArn: !GetAtt MieUserPool.Arn
-        DeploymentPackageBucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        DeploymentPackageBucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         DeploymentPackageKey:
           !Join [
             "/",
@@ -1157,7 +1157,7 @@ Resources:
           "/",
           [
             "https://s3.amazonaws.com",
-            !FindInMap ["SourceCode", "General", "S3Bucket"],
+            !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]],
             !FindInMap ["SourceCode", "General", "TemplateKeyPrefix"],
             "media-insights-dataplane-streaming-stack.template",
           ],
@@ -1181,7 +1181,7 @@ Resources:
           "/",
           [
             "https://s3.amazonaws.com",
-            !FindInMap ["SourceCode", "General", "S3Bucket"],
+            !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]],
             !FindInMap ["SourceCode", "General", "TemplateKeyPrefix"],
             "media-insights-workflowapi-stack.template",
           ],
@@ -1219,7 +1219,7 @@ Resources:
             - Outputs.APIHandlerArn
         DataPlaneBucket: !Ref Dataplane
         OperatorFailedHandlerLambdaArn: !GetAtt OperatorFailedLambda.Arn
-        DeploymentPackageBucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        DeploymentPackageBucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         DeploymentPackageKey:
           !Join [
             "/",
@@ -1249,7 +1249,7 @@ Resources:
           "/",
           [
             "https://s3.amazonaws.com",
-            !FindInMap ["SourceCode", "General", "S3Bucket"],
+            !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]],
             !FindInMap ["SourceCode", "General", "TemplateKeyPrefix"],
             "media-insights-operator-library.template",
           ],
@@ -1277,7 +1277,7 @@ Resources:
           "/",
           [
             "https://s3.amazonaws.com",
-            !FindInMap ["SourceCode", "General", "S3Bucket"],
+            !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]],
             !FindInMap ["SourceCode", "General", "TemplateKeyPrefix"],
             "media-insights-test-operations-stack.template",
           ],
@@ -1308,7 +1308,7 @@ Resources:
           "/",
           [
             "https://s3.amazonaws.com",
-            !FindInMap ["SourceCode", "General", "S3Bucket"],
+            !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]],
             !FindInMap ["SourceCode", "General", "TemplateKeyPrefix"],
             "instant_translate.template",
           ],
@@ -1332,7 +1332,7 @@ Resources:
   #          "/",
   #          [
   #            "https://s3.amazonaws.com",
-  #            !FindInMap ["SourceCode", "General", "S3Bucket"],
+  #            !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]],
   #            !FindInMap ["SourceCode", "General", "TemplateKeyPrefix"],
   #            "transcribe.template",
   #          ],
@@ -1357,7 +1357,7 @@ Resources:
           "/",
           [
             "https://s3.amazonaws.com",
-            !FindInMap ["SourceCode", "General", "S3Bucket"],
+            !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]],
             !FindInMap ["SourceCode", "General", "TemplateKeyPrefix"],
             "rekognition.template",
           ],
@@ -1382,7 +1382,7 @@ Resources:
           "/",
           [
             "https://s3.amazonaws.com",
-            !FindInMap ["SourceCode", "General", "S3Bucket"],
+            !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]],
             !FindInMap ["SourceCode", "General", "TemplateKeyPrefix"],
             "comprehend.template",
           ],
@@ -1407,7 +1407,7 @@ Resources:
           "/",
           [
             "https://s3.amazonaws.com",
-            !FindInMap ["SourceCode", "General", "S3Bucket"],
+            !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]],
             !FindInMap ["SourceCode", "General", "TemplateKeyPrefix"],
             "MieCompleteWorkflow.template",
           ],
@@ -1430,7 +1430,7 @@ Resources:
           "/",
           [
             "https://s3.amazonaws.com",
-            !FindInMap ["SourceCode", "General", "S3Bucket"],
+            !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]],
             !FindInMap ["SourceCode", "General", "TemplateKeyPrefix"],
             "string.template",
           ],
@@ -1450,7 +1450,7 @@ Resources:
           "/",
           [
             "https://s3.amazonaws.com",
-            !FindInMap ["SourceCode", "General", "S3Bucket"],
+            !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]],
             !FindInMap ["SourceCode", "General", "TemplateKeyPrefix"],
             "media-insights-webapp.template",
           ],
@@ -1476,7 +1476,7 @@ Resources:
 #          "/",
 #          [
 #            "https://s3.amazonaws.com",
-#            !FindInMap ["SourceCode", "General", "S3Bucket"],
+#            !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]],
 #            !FindInMap ["SourceCode", "General", "TemplateKeyPrefix"],
 #            "transcriber-webapp.template",
 #          ],

--- a/deployment/media-insights-stack.yaml
+++ b/deployment/media-insights-stack.yaml
@@ -634,8 +634,6 @@ Resources:
             AllowedMethods: ["GET", "POST"]
             AllowedOrigins: ["*"]
             Id: AllowUploadsFromWebApp
-      VersioningConfiguration:
-        Status: "Enabled"
 
   DataplaneBucketPolicy:
     Type: "AWS::S3::BucketPolicy"

--- a/deployment/media-insights-test-operations-stack.yaml
+++ b/deployment/media-insights-test-operations-stack.yaml
@@ -69,7 +69,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-video-sync-ok"
       Handler: test.video_sync_ok_lambda_handler
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "test_operations.zip"]]
       Layers:
         - !Ref "MediaInsightsEnginePython37Layer"
@@ -91,7 +91,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-video-sync-fail"
       Handler: test.video_sync_fail_lambda_handler
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "test_operations.zip"]]
       Layers:
         - !Ref "MediaInsightsEnginePython37Layer"
@@ -113,7 +113,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-video-async-ok"
       Handler: test.video_async_ok_lambda_handler
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "test_operations.zip"]]
       Layers:
         - !Ref "MediaInsightsEnginePython37Layer"
@@ -135,7 +135,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-video-async-ok-monitor"
       Handler: test.video_async_ok_monitor_lambda_handler
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "test_operations.zip"]]
       Layers:
         - !Ref "MediaInsightsEnginePython37Layer"
@@ -157,7 +157,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-video-async-fail-monitor"
       Handler: test.video_async_fail_monitor_lambda_handler
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "test_operations.zip"]]
       Layers:
         - !Ref "MediaInsightsEnginePython37Layer"
@@ -179,7 +179,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-audio-sync-ok"
       Handler: test.audio_sync_ok_lambda_handler
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "test_operations.zip"]]
       Layers:
         - !Ref "MediaInsightsEnginePython37Layer"
@@ -201,7 +201,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-audio-async-ok"
       Handler: test.audio_async_ok_lambda_handler
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "test_operations.zip"]]
       Layers:
         - !Ref "MediaInsightsEnginePython37Layer"
@@ -223,7 +223,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-audio-async-ok-monitor"
       Handler: test.audio_async_ok_monitor_lambda_handler
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "test_operations.zip"]]
       Layers:
         - !Ref "MediaInsightsEnginePython37Layer"
@@ -245,7 +245,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-image-sync-ok"
       Handler: test.image_sync_ok_lambda_handler
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "test_operations.zip"]]
       Layers:
         - !Ref "MediaInsightsEnginePython37Layer"
@@ -267,7 +267,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-image-async-ok"
       Handler: test.image_async_ok_lambda_handler
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "test_operations.zip"]]
       Layers:
         - !Ref "MediaInsightsEnginePython37Layer"
@@ -289,7 +289,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-image-async-ok-monitor"
       Handler: test.image_async_ok_monitor_lambda_handler
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "test_operations.zip"]]
       Layers:
         - !Ref "MediaInsightsEnginePython37Layer"
@@ -311,7 +311,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-text-sync-ok"
       Handler: test.text_sync_ok_lambda_handler
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "test_operations.zip"]]
       Layers:
         - !Ref "MediaInsightsEnginePython37Layer"
@@ -333,7 +333,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-text-async-ok"
       Handler: test.text_async_ok_lambda_handler
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "test_operations.zip"]]
       Layers:
         - !Ref "MediaInsightsEnginePython37Layer"
@@ -355,7 +355,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-text-async-ok-monitor"
       Handler: test.text_async_ok_monitor_lambda_handler
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "test_operations.zip"]]
       Layers:
         - !Ref "MediaInsightsEnginePython37Layer"

--- a/source/consumers/elastic/media-insights-elasticsearch.yaml
+++ b/source/consumers/elastic/media-insights-elasticsearch.yaml
@@ -106,7 +106,7 @@ Resources:
       Handler: "lambda_handler.lambda_handler"
       Role: !GetAtt ElasticConsumerRole.Arn
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",

--- a/source/operators/operator-library.yaml
+++ b/source/operators/operator-library.yaml
@@ -530,7 +530,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt genericDataLookupLambdaRole.Arn
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -557,7 +557,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt mediainfoLambdaRole.Arn
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -585,7 +585,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt comprehendRole.Arn
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -611,7 +611,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt comprehendRole.Arn
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -637,7 +637,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt comprehendRole.Arn
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -663,7 +663,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt comprehendRole.Arn
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -692,7 +692,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt "rekognitionRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -720,7 +720,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt "rekognitionRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -747,7 +747,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt "rekognitionRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -775,7 +775,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt "rekognitionRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -802,7 +802,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt "rekognitionRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -831,7 +831,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt "rekognitionRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -859,7 +859,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt "rekognitionRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -888,7 +888,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt "rekognitionRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -917,7 +917,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt "rekognitionRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -944,7 +944,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt "rekognitionRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -973,7 +973,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt "rekognitionRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1000,7 +1000,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt "rekognitionRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1028,7 +1028,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt "rekognitionRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1053,7 +1053,7 @@ Resources:
         - !Ref MediaInsightsEnginePython37Layer
       Role: !GetAtt "rekognitionRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1083,7 +1083,7 @@ Resources:
         - !Ref "MediaInsightsEnginePython37Layer"
       Role: !GetAtt "mediaConvertLambdaRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1108,7 +1108,7 @@ Resources:
         - !Ref "MediaInsightsEnginePython37Layer"
       Role: !GetAtt "mediaConvertLambdaRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1133,7 +1133,7 @@ Resources:
         - !Ref "MediaInsightsEnginePython37Layer"
       Role: !GetAtt "mediaConvertLambdaRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1158,7 +1158,7 @@ Resources:
         - !Ref "MediaInsightsEnginePython37Layer"
       Role: !GetAtt "mediaConvertLambdaRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1184,7 +1184,7 @@ Resources:
         - !Ref "MediaInsightsEnginePython37Layer"
       Role: !GetAtt "transcribeRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1208,7 +1208,7 @@ Resources:
         - !Ref "MediaInsightsEnginePython37Layer"
       Role: !GetAtt "transcribeRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1236,7 +1236,7 @@ Resources:
         - !Ref "MediaInsightsEnginePython37Layer"
       Role: !GetAtt "captionsRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1262,7 +1262,7 @@ Resources:
         - !Ref "MediaInsightsEnginePython37Layer"
       Role: !GetAtt "captionsRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1286,7 +1286,7 @@ Resources:
         - !Ref "MediaInsightsEnginePython37Layer"
       Role: !GetAtt "captionsRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1310,7 +1310,7 @@ Resources:
         - !Ref "MediaInsightsEnginePython37Layer"
       Role: !GetAtt "captionsRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1334,7 +1334,7 @@ Resources:
         - !Ref "MediaInsightsEnginePython37Layer"
       Role: !GetAtt "captionsRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1360,7 +1360,7 @@ Resources:
         - !Ref "MediaInsightsEnginePython37Layer"
       Role: !GetAtt "translateRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1388,7 +1388,7 @@ Resources:
         - !Ref "MediaInsightsEnginePython37Layer"
       Role: !GetAtt "pollyRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -1412,7 +1412,7 @@ Resources:
         - !Ref "MediaInsightsEnginePython37Layer"
       Role: !GetAtt "pollyRole.Arn"
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",

--- a/source/webapp/media-insights-webapp.yaml
+++ b/source/webapp/media-insights-webapp.yaml
@@ -69,8 +69,6 @@ Resources:
             ExpirationInDays: 30
             AbortIncompleteMultipartUpload:
               DaysAfterInitiation: 1
-      VersioningConfiguration:
-        Status: "Enabled"
 
   WebBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -117,7 +115,7 @@ Resources:
                   - !Sub ${MediaInsightsWebsiteBucket.Arn}/*
                   - Fn::Sub:
                       - arn:aws:s3:::${websitecode}/*
-                      - websitecode: !FindInMap ["SourceCode", "General", "S3Bucket"]
+                      - websitecode: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
               - Effect: Allow
                 Action:
                   - "s3:ListBucket"
@@ -125,7 +123,7 @@ Resources:
                   - !Sub ${MediaInsightsWebsiteBucket.Arn}
                   - Fn::Sub:
                       - arn:aws:s3:::${websitecode}
-                      - websitecode: !FindInMap ["SourceCode", "General", "S3Bucket"]
+                      - websitecode: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
               - Effect: Allow
                 Action:
                   - "logs:CreateLogGroup"
@@ -138,7 +136,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key:
           !Join [
             "/",
@@ -168,7 +166,7 @@ Resources:
     Type: Custom::WebsiteDeployHelper
     Properties:
       ServiceToken: !GetAtt WebsiteDeployHelper.Arn
-      WebsiteCodeBucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+      WebsiteCodeBucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
       WebsiteCodePrefix: !FindInMap ["SourceCode", "General", "WebsitePrefix"]
       DeploymentBucket: !GetAtt MediaInsightsWebsiteBucket.DomainName
 

--- a/source/webapp/src/views/Analysis.vue
+++ b/source/webapp/src/views/Analysis.vue
@@ -289,7 +289,9 @@
           return data.getIdToken().getJwtToken();
         });
         const bucket = this.s3_uri.split("/")[2];
-        const key = this.s3_uri.split(this.s3_uri.split("/")[2] + '/')[1];
+        // TODO: Get the path to the proxy mp4 from the mediaconvert operator
+        // Our mediaconvert operator sets proxy encode filename to [key]_proxy.mp4
+        const key = (this.s3_uri.split(this.s3_uri.split("/")[2] + '/')[1].replace('input/','')).split(".")[0] + "_proxy.mp4";
         // get URL to video file in S3
         fetch(this.DATAPLANE_API_ENDPOINT + '/download', {
           method: 'POST',

--- a/source/webapp/src/views/Analysis.vue
+++ b/source/webapp/src/views/Analysis.vue
@@ -273,8 +273,7 @@
               let fileType = filename.split('.').slice(-1)[0]
               if (this.supportedImageFormats.includes(fileType.toLowerCase()) ) {
                 this.mediaType = "image"
-              }
-              if (fileType.toLowerCase() === "mp4") {
+              } else {
                 this.mediaType = "video"
               }
               this.filename = filename;
@@ -291,7 +290,16 @@
         const bucket = this.s3_uri.split("/")[2];
         // TODO: Get the path to the proxy mp4 from the mediaconvert operator
         // Our mediaconvert operator sets proxy encode filename to [key]_proxy.mp4
-        const key = (this.s3_uri.split(this.s3_uri.split("/")[2] + '/')[1].replace('input/','')).split(".")[0] + "_proxy.mp4";
+        let key="";
+        if (this.mediaType === "image") {
+          key = this.s3_uri.split(this.s3_uri.split("/")[2] + '/')[1];
+        }
+        if (this.mediaType === "video") {
+          const media_key = (this.s3_uri.split(this.s3_uri.split("/")[2] + '/')[1].replace('input/', ''))
+          const proxy_encode_key = media_key.split(".").slice(0,-1).join('.') + "_proxy.mp4";
+          key = proxy_encode_key
+        }
+        console.log("here")
         // get URL to video file in S3
         fetch(this.DATAPLANE_API_ENDPOINT + '/download', {
           method: 'POST',


### PR DESCRIPTION
* Allow users to upload webm files.

* Use the proxy encode mp4 for the video player in the GUI, so we don't get errors with file types that aren't supported by videojs.

* Disable versioning on website bucket because so that bucket can be removed more easily

* Update CloudFormation templates so they resolve user-specified region at deploy time instead of at build time. This way the same templates can be used in any region.

* fix bug with determining key to proxy encode mp4
