### PR TITLE
Bump jquery from 1.12.4 to 3.4.1 in /source/webapp

### DIFF
--- a/source/webapp/package.json
+++ b/source/webapp/package.json
@@ -16,7 +16,7 @@
     "chart.js": "^2.9.3",
     "core-js": "^2.6.11",
     "dropzone": "^5.7.0",
-    "jquery": "^1.12.4",
+    "jquery": "^3.4.1",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.15",
     "register-service-worker": "^1.6.2",


### PR DESCRIPTION
*Description of changes:*

Bumps jquery from 1.12.4 to 3.4.1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
