### PR TITLE
Update README.md

### DIFF
--- a/source/webapp/README.md
+++ b/source/webapp/README.md
@@ -49,7 +49,7 @@ git clone https://github.com/awslabs/aws-media-insights-engine
 
 ### Install the packages in package.json
 ```
-cd MediaInsightsEngine/webapp
+cd aws-media-insights-engine/source/webapp/
 npm install
 ```
 

--- a/source/webapp/README.md
+++ b/source/webapp/README.md
@@ -44,7 +44,7 @@ nvm install --latest-npm
 
 ### Download MIE 
 ```
-git clone ssh://git.amazon.com/pkg/MediaInsightsEngine
+git clone https://github.com/awslabs/aws-media-insights-engine
 ```
 
 ### Install the packages in package.json

--- a/source/webapp/README.md
+++ b/source/webapp/README.md
@@ -29,7 +29,7 @@ Here's how to run this project on an Amazon Linux Docker container:
 
 ### Start an Amazon Linux container
 ```
-docker run -it amazonlinux
+docker run -p 8080:8080 -it amazonlinux
 yum groupinstall "Development Tools" -y
 ```
 


### PR DESCRIPTION
This particular instruction for cloning repository appears to be incorrect:

sh-4.2# git clone ssh://git.amazon.com/pkg/MediaInsightsEngine
Cloning into 'MediaInsightsEngine'...
ssh: Could not resolve hostname git.amazon.com: Name or service not known
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

Instead, we can use:
sh-4.2# git clone https://github.com/awslabs/aws-media-insights-engine
Cloning into 'aws-media-insights-engine'...
remote: Enumerating objects: 106, done.
remote: Counting objects: 100% (106/106), done.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
