### PR TITLE
Prevent duplication of this.entities

### DIFF
--- a/source/webapp/src/components/ComprehendEntities.vue
+++ b/source/webapp/src/components/ComprehendEntities.vue
@@ -64,6 +64,8 @@ export default {
   },
   deactivated: function () {
     console.log('deactivated component:', this.operator)
+    // clearing this value after every deactivation so we dont carry this huge amount of data in memory
+    this.entities = []
   },
   activated: function () {
     console.log('activated component:', this.operator);


### PR DESCRIPTION
If user switches from Entities to KeyPhrases tab and back, this.entities doubles in size. 
To prevent this, we can employ the same method of clearing memory that is used in ComprehendKeyPhrases

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
