### PR TITLE
Added Cognito Identity Pool ID to the output of CF

### DIFF
--- a/deployment/media-insights-stack.yaml
+++ b/deployment/media-insights-stack.yaml
@@ -1531,6 +1531,9 @@ Outputs:
   UserPoolId:
     Description: ID of the MIE Cognito User Pool
     Value: !Ref MieUserPool
+  IdentityPoolId:
+    Description: ID of the MIE Cognito Identity Pool
+    Value: !Ref MieIdentityPool
   AdminClientId:
     Description: ID of the Admin Cognito Client. This can be used to authenticate command-line apps using boto3.
     Value: !Ref MieAdminClient


### PR DESCRIPTION
When developing the web-application, it is useful to be able to point your local dev instance to services deployed in the cloud. Almost all values a developer needs to populate runtimeConfig.json file are available within the CloudFormation stack outputs, apart from IDENTITY_POOL_ID. 
This is an attempt to add it