### PR TITLE
Added ListBucket to Dataplane bucket policy for better debugging and minor documentation correction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ deployment/lambda_layer_factory/lambda_layer-python-*
 *.DS_Store
 *.iml
 .idea/
+.vscode/
 
 # these are not checked in to o.g. git project
 package-lock.json

--- a/IMPLEMENTATION_GUIDE.md
+++ b/IMPLEMENTATION_GUIDE.md
@@ -414,7 +414,7 @@ export WORKFLOW_API_ENDPOINT=$(aws cloudformation describe-stacks --stack-name $
 
 Get the token like this:
 ```
-export MIE_ACCESS_TOKEN=$(VENV=$(mktemp -d); python3 -m venv $VENV; source $VENV/bin/activate; pip --disable-pip-version-check install -q boto3; python3 $MIE_DEVELOPMENT_HOME/tests/getAccessToken.py | tail -n 1; deactivate; rm -rf $VENV)
+export MIE_ACCESS_TOKEN=$(VENV=$(mktemp -d); python3 -m venv $VENV; source $VENV/bin/activate; pip --disable-pip-version-check install -q boto3; python3 $MIE_DEVELOPMENT_HOME/source/tests/getAccessToken.py | tail -n 1; deactivate; rm -rf $VENV)
 ```
 
 If you set MIE_PASSWORD to your temporary password, you will be prompted to update this password. Update your exported MIE_PASSWORD with the updated one. 

--- a/source/dataplaneapi/external_resources.json
+++ b/source/dataplaneapi/external_resources.json
@@ -48,6 +48,11 @@
                 },
                 {
                   "Effect": "Allow",
+                  "Action": "s3:ListBucket",
+                  "Resource": {"Fn::Sub": "arn:aws:s3:::${DataplaneBucketName}"}
+                },
+                {
+                  "Effect": "Allow",
                   "Action": "dynamodb:*",
                   "Resource": {"Fn::Sub": "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${DataplaneTableName}"}
                 },


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Updated the Dataplane API Handler's Role policy to include a ListBucket action on the Dataplane S3 bucket. This is done so that the developer gets a NoSuchKey error when accessing an invalid S3 key instead of getting AccessDenied. The incorrect message makes it hard to debug especially when all required permissions for execution of the Lambda exist.

Updated the path under Implementation guide to reflect the correct path when exporting the MIE_ACCESS_TOKEN. Currently: $MIE_DEVELOPMENT_HOME/tests/getAccessToken.py.
Proposed change: $MIE_DEVELOPMENT_HOME/source/tests/getAccessToken.py

Added .vscode/ to gitignore as a QOL improvement for VSCode users.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.