### PR TITLE
#254 set s3 signature_version to s3v4

### DIFF
--- a/source/dataplaneapi/app.py
+++ b/source/dataplaneapi/app.py
@@ -224,7 +224,8 @@ def download():
         ChaliceViewError - 500
     """
     print('/download request: '+app.current_request.raw_body.decode())
-    s3 = boto3.client('s3')
+    region = os.environ['AWS_REGION']
+    s3 = boto3.client('s3', region_name=region, config = Config(signature_version = 's3v4', s3={'addressing_style': 'virtual'}))
     # expire the URL in
     try:
         response = s3.generate_presigned_url('get_object',


### PR DESCRIPTION
*Issue #, if available:* #254 

*Description of changes:*

Set region and signature version in S3 client to ensure that SigV4 signing is used for S3 presigned url requests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
