### PR TITLE
#272 Handle errors that terminate state machines

### DIFF
--- a/deployment/media-insights-stack.yaml
+++ b/deployment/media-insights-stack.yaml
@@ -284,6 +284,13 @@ Resources:
         - PolicyName: !Sub "${AWS::StackName}-operation-lambda"
           PolicyDocument:
             Statement:
+              - Effect: "Allow"
+                Action:
+                  - "states:DescribeExecution"
+                  - "states:GetExecutionHistory"
+                  - "states:StopExecution"
+                Resource:
+                  - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:execution:*:*"
               - Effect: Allow
                 Action:
                   - states:StartExecution
@@ -769,6 +776,83 @@ Resources:
             - Arn
     Type: AWS::Lambda::Function
 
+  # Workflow state machine error handler
+  WorkflowErrorHandlerLambda:
+    Properties:
+      Environment:
+        Variables:
+          STAGE_EXECUTION_QUEUE_URL: !Ref StageExecutionQueue
+          STAGE_TABLE_NAME: !Ref StageTable
+          OPERATION_TABLE_NAME: !Ref OperationTable
+          WORKFLOW_EXECUTION_TABLE_NAME: !Ref WorkflowExecutionTable
+          WORKFLOW_TABLE_NAME: !Ref WorkflowTable
+          SYSTEM_TABLE_NAME: !Ref SystemTable
+          DEFAULT_MAX_CONCURRENT_WORKFLOWS: !Ref MaxConcurrentWorkflows
+          ShortUUID: !GetAtt GetShortUUID.Data
+          WORKFLOW_SCHEDULER_LAMBDA_ARN:
+            Fn::GetAtt:
+              - WorkflowSchedulerLambda
+              - Arn
+      Handler: app.workflow_error_handler_lambda
+      TracingConfig: 
+          Mode: !If [EnableTraceOnEntryPoints, "Active", "PassThrough"]
+      Code:
+        S3Bucket: !FindInMap ["SourceCode", "General", "S3Bucket"]
+        S3Key:
+          !Join [
+            "/",
+            [
+            !FindInMap ["SourceCode", "General", "CodeKeyPrefix"],
+            "workflow.zip",
+            ],
+          ]
+      Layers:
+        - !Ref "MediaInsightsEnginePython37Layer"
+      MemorySize: 256
+      Role:
+        Fn::GetAtt:
+          - OperationLambdaExecutionRole
+          - Arn
+      Runtime: python3.7
+      Timeout: 900
+      ReservedConcurrentExecutions: 1
+      DeadLetterConfig:
+        TargetArn:
+          Fn::GetAtt:
+            - WorkflowExecutionLambdaDeadLetterQueue
+            - Arn
+    Type: AWS::Lambda::Function
+
+  StateMachineErrorCloudWatchEvent:
+    Type: AWS::Events::Rule
+    Properties:
+        Name: !Sub "${AWS::StackName}-state-machine-error-handler"
+        Description: "state machine error handler"  
+        EventPattern:
+            source:
+                - "aws.states"
+            detail-type:
+                - "Step Functions Execution Status Change"
+            detail:
+                status:
+                    - FAILED
+                    - ABORTED
+                    - TIMED_OUT
+        State: ENABLED
+        Targets:
+            -
+                Id: !Ref WorkflowErrorHandlerLambda
+                Arn: !GetAtt WorkflowErrorHandlerLambda.Arn
+
+  PermissionToInvokeLambda:
+      Type: AWS::Lambda::Permission
+      Properties:
+          FunctionName: !Ref WorkflowErrorHandlerLambda
+          Action: lambda:InvokeFunction
+          Principal: events.amazonaws.com
+          SourceArn: !GetAtt StateMachineErrorCloudWatchEvent.Arn
+  
+
   CompleteStageLambda:
     DependsOn:
       - WorkflowSchedulerLambda
@@ -864,7 +948,7 @@ Resources:
       Layers:
         - !Ref "MediaInsightsEnginePython37Layer"
       Runtime: "python3.7"
-
+  
   # DataPlane API Stack
   MediaInsightsDataplaneApiStack:
     Type: "AWS::CloudFormation::Stack"

--- a/source/workflow/app.py
+++ b/source/workflow/app.py
@@ -564,7 +564,7 @@ def get_execution_errors(arn):
         for page in page_iterator:
             for event in page["events"]:
               if (any(sub in event["type"] for sub in ['Failed', 'Aborted', 'TimedOut'])):
-                  logger.info("Found error event: {}".format(json.dumps(event)))
+                  logger.info("Found error event: {}".format(event))
                   executions.append(event)
 
         return executions

--- a/source/workflow/app.py
+++ b/source/workflow/app.py
@@ -54,8 +54,6 @@ else:
 
 if "ShortUUID" in os.environ:
     ShortUUID = os.environ["ShortUUID"]
-else:
-    ""
 
 if "DEFAULT_MAX_CONCURRENT_WORKFLOWS" in os.environ:
     DEFAULT_MAX_CONCURRENT_WORKFLOWS = int(os.environ["DEFAULT_MAX_CONCURRENT_WORKFLOWS"])
@@ -607,11 +605,10 @@ def workflow_error_handler_lambda (event, context):
     
     logger.info("workflow_error_handler_lambda: {}".format(json.dumps(event))) 
     
-    if ShortUUID == "":
+    if not ShortUUID:
         raise Exception('ShortUUID is not set in lambda environment.') 
-    else:
-        logger.info("Process step function error event for stack with ShortUUID {}".format(ShortUUID))
-    
+        
+    logger.info("Process step function error event for stack with ShortUUID {}".format(ShortUUID))
     
     if not ("detail" in event): 
         raise Exception('event.detail is missing.') 

--- a/source/workflow/app.py
+++ b/source/workflow/app.py
@@ -52,6 +52,11 @@ if "SYSTEM_TABLE_NAME" in os.environ:
 else:
     ""
 
+if "ShortUUID" in os.environ:
+    ShortUUID = os.environ["ShortUUID"]
+else:
+    ""
+
 if "DEFAULT_MAX_CONCURRENT_WORKFLOWS" in os.environ:
     DEFAULT_MAX_CONCURRENT_WORKFLOWS = int(os.environ["DEFAULT_MAX_CONCURRENT_WORKFLOWS"])
 else:
@@ -105,7 +110,7 @@ def workflow_scheduler_lambda(event, context):
     empty = False
 
     try:
-        print(json.dumps(event))
+        logger.info(json.dumps(event))
 
         # Get the MaxConcurrent configruation parameter, if it is not set, use the default
         system_table = DYNAMO_RESOURCE.Table(SYSTEM_TABLE_NAME)
@@ -301,7 +306,7 @@ def complete_stage_execution(trigger, stage_name, status, outputs, workflow_exec
                 if "Media" in operation:
                     for mediaType in operation["Media"].keys():
                         # replace media with trasformed or created media from this stage
-                        print(mediaType)
+                        logger.info(mediaType)
                         if mediaType in stageOutputMediaTypeKeys:
 
                             raise ValueError(
@@ -314,7 +319,7 @@ def complete_stage_execution(trigger, stage_name, status, outputs, workflow_exec
                 stageOutputMetadataKeys = []
                 if "MetaData" in operation:
                     for key in operation["MetaData"].keys():
-                        print(key)
+                        logger.info(key)
                         if key in stageOutputMetadataKeys:
                             raise ValueError(
                                 "Duplicate key '%s' found in operation ouput metadata.  Metadata keys must be unique within a stage." % key)
@@ -383,7 +388,7 @@ def complete_stage_execution(trigger, stage_name, status, outputs, workflow_exec
 def start_next_stage_execution(trigger, stage_name, workflow_execution):
 
     try:
-        print("START NEXT STAGE: stage_name {}".format(stage_name))
+        logger.info("START NEXT STAGE: stage_name {}".format(stage_name))
 
         execution_table = DYNAMO_RESOURCE.Table(WORKFLOW_EXECUTION_TABLE_NAME)
 
@@ -467,7 +472,7 @@ def start_next_stage_execution(trigger, stage_name, workflow_execution):
                 )
                 
                 update_workflow_execution_status(workflow_execution["Id"], workflow_execution["Status"], message)
-                print(json.dumps(workitem))
+                logger.info(json.dumps(workitem))
 
             except Exception as e:
                 message = "Exception queuing work item: {} ".format(e)
@@ -503,7 +508,7 @@ def update_workflow_execution_status(id, status, message):
     :param status: The new status of the workflow execution
 
     """
-    print("Update workflow execution {} set status = {}".format(id, status))
+    logger.info("Update workflow execution {} set status = {}".format(id, status))
     execution_table = DYNAMO_RESOURCE.Table(WORKFLOW_EXECUTION_TABLE_NAME)
     
     if status == awsmie.WORKFLOW_STATUS_ERROR:
@@ -542,4 +547,109 @@ def update_workflow_execution_status(id, status, message):
             InvocationType='Event'
         )
 
+# Find all of the execution error events for a state machine execution
+def get_execution_errors(arn):
+    
+    try:
+        
+        executions = []
+        paginator = SFN_CLIENT.get_paginator('get_execution_history')
 
+        # return all the history
+        page_iterator = paginator.paginate(executionArn=arn, 
+                maxResults= 20, 
+                reverseOrder=True)
+
+        # return only the history with exceptions
+        for page in page_iterator:
+            for event in page["events"]:
+              if (any(sub in event["type"] for sub in ['Failed', 'Aborted', 'TimedOut'])):
+                  logger.info("Found error event: {}".format(json.dumps(event)))
+                  executions.append(event)
+
+        return executions
+    
+    except:
+        logger.error("Unable to retrieve execution history for state machine termination")
+        raise
+
+# Find the earliest error message in the executions and retrieve additonal info if available
+def parse_execution_error(arn, executions, status): 
+
+    message = "Caught Step Function Execution Status Change event for execution: "+ arn +", status:"+ status
+
+    # return the cause info from the most recent failure, if any
+    for execution in executions:
+      for key, value in execution.items():
+        if (any(sub in key for sub in ['Failed', 'Aborted', 'TimedOut'])):
+          if "cause" in value:
+              message = message+", cause: "+value["cause"] 
+              break
+
+    return message
+
+# This lambda is invoked for Step Functions Execution Status Change events 
+# that contain the status [ERROR, ABORTED, TIME_OUT].  Failures that occur
+# within the steps of a workflow state machine are handled by the 
+# OperotorFailed lambda function, but if the state machine service throws 
+# an exception that causes the state machine to terminate immediately, 
+# it can't be handled within the state machine because the execution
+# is haulted.
+# 
+# Info on events handled here: 
+#     https://docs.aws.amazon.com/step-functions/latest/dg/cw-events.html 
+#
+# Propagate the error and cause to the workflow control plane to close off
+# the workflow execution
+def workflow_error_handler_lambda (event, context): 
+ 
+  try: 
+    
+    logger.info("workflow_error_handler_lambda: {}".format(json.dumps(event))) 
+    
+    if ShortUUID == "":
+        raise Exception('ShortUUID is not set in lambda environment.') 
+    else:
+        logger.info("Process step function error event for stack with ShortUUID {}".format(ShortUUID))
+    
+    
+    if not ("detail" in event): 
+        raise Exception('event.detail is missing.') 
+    if not "name" in event["detail"]:
+        raise Exception('name is missing in event.detail.')
+    if not "status" in event["detail"]:
+        raise Exception('status is missing in event.detail.')
+    if not "executionArn" in event["detail"]:
+        raise Exception('status is missing in event.detail.')
+
+    # only process events for state machines that are part of this stack
+    if not event["detail"]["stateMachineArn"].find(ShortUUID):
+        logger.info("Event not processed: This event is not from the stack with ShortUUID {}".format(ShortUUID))
+        return {}
+
+    executions = get_execution_errors(event["detail"]["executionArn"])
+
+    message = parse_execution_error(event["detail"]["executionArn"], executions, event["detail"]["status"]) 
+ 
+    #input = event.detail.input 
+    stateMachineExecution = event["detail"]["executionArn"]
+
+    # Check the currently active workflows for this execution arn and set the 
+    # status to error if found.  
+    started_workflows = list_workflow_executions_by_status(awsmie.WORKFLOW_STATUS_STARTED) 
+    for workflow in started_workflows:
+        if workflow["StateMachineExecutionArn"] == event["detail"]["executionArn"]:
+            update_workflow_execution_status(workflow["Id"], awsmie.WORKFLOW_STATUS_ERROR, message)
+ 
+    response = {  
+      "stateMachineExecution": stateMachineExecution, 
+      "errorMessage": message 
+    } 
+
+    logger.info("workflow_error_handler_lambda caught error: {}".format(json.dumps(response)))
+ 
+    return response
+  except Exception as e:
+    logger.error("Unable to handle workflow step function error: {}".format(e))
+    raise(e)
+ 


### PR DESCRIPTION
## Issue #, if available: 
#272 

## Description of changes:

Added a new lambda resource, `WorkflowErrorHandlerLambda`, that is triggered by  `Step Functions Execution Status Change` EventBridge events that have an error status (`FAILED, TIMED_OUT, ABORTED`).

The `WorkflowErrorHandlerLambda` extracts the error information from the state machine execution history and propagates the error to the MIE control plane.

In order to handle multiple MIE stacks deployed in the same region, the event handler checks for the stack SHORT_UUID in the workflow name.  If the workflow name does not contain the stack, then it returns without handling the error.  The alternative to this would be to use the "prefix" event filter on the workflow name.  In order to do this, we would need to change the naming of workflows to be SHORT_UUID+WorkflowName instead of WorkflowName+SHORT_UUID.

I have a separate pull request to update the implementation guide with error handling info.
See also: https://github.com/awslabs/aws-media-insights/pull/24

## Testing:

I tested the error handler e2e manually with ABORTED and TIME_OUT events.  I simulated a failure event by pasting in event JSON to the lambda function.

## Future work:

#271 Add a configurable workflow timeout to the create workflow API
#270 Refactor workflowapi and workflow lambdas to use a library import for shared code 
#269 Automated integration test for workflow state machine execution failure that immediately terminate the execution 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
