### PR TITLE
Allmetadata

### DIFF
--- a/test/integ/dataplaneapi/conftest.py
+++ b/test/integ/dataplaneapi/conftest.py
@@ -133,17 +133,23 @@ class API:
 
     # TODO: This test is currently broken. Seems to be a real issue with the API that needs looked into.
 
-    # def get_all_metadata(self, asset_id, cursor=None):
-    #     if cursor is None:
-    #         url = self.stack_resources["DataplaneApiEndpoint"] + 'metadata/' + asset_id
-    #     else:
-    #         url = self.stack_resources["DataplaneApiEndpoint"] + 'metadata/' + asset_id + "?cursor=" + cursor
-    #     headers = {"Content-Type": "application/json"}
-    #     print("GET /metadata/{asset}".format(asset=asset_id))
-    #     metadata_response = requests.get(url, headers=headers, verify=False, auth=self.auth)
-    #     print(metadata_response.json())
-    #     print(metadata_response.text)
-    #     return metadata_response
+    def get_all_metadata(self, asset_id, cursor=None):
+        
+        url = self.stack_resources["DataplaneApiEndpoint"] + 'metadata/' + asset_id
+        headers = {"Content-Type": "application/json"}
+        print("GET /metadata/{asset}".format(asset=asset_id))
+        
+        if cursor is None:
+            print("GET /metadata/{asset}".format(asset=asset_id))
+            metadata_response = requests.get(url, headers=headers, verify=False, auth=self.auth) 
+        else:
+            print("GET /metadata/{asset}?cursor={cursor}".format(asset=asset_id, cursor=cursor))
+            query_params = {"cursor": cursor}
+            metadata_response = requests.get(url, headers=headers, params=query_params, verify=False, auth=self.auth) 
+        
+        print(metadata_response.json())
+        print(metadata_response.text)
+        return metadata_response
 
     def get_single_metadata_field(self, asset_id, operator):
         metadata_field = operator["OperatorName"]

--- a/test/integ/dataplaneapi/test_dataplane_crud.py
+++ b/test/integ/dataplaneapi/test_dataplane_crud.py
@@ -93,21 +93,21 @@ def test_dataplane_api(dataplane_api):
 
     # Retrieve all metadata from the asset
 
-    # print("Retrieving all metadata for the asset: {asset}".format(asset=asset_id))
-    #
-    # cursor = None
-    #
-    # more_results = True
-    # while more_results:
-    #     retrieve_metadata_response = api.get_all_metadata(asset_id, cursor)
-    #     assert retrieve_metadata_response.status_code == 200
-    #     retrieved_metadata = retrieve_metadata_response.json()
-    #     print(retrieved_metadata)
-    #     if "cursor" in retrieved_metadata:
-    #         cursor = retrieved_metadata["cursor"]
-    #     else:
-    #         more_results = False
-    # print("Successfully retrieved all metadata for asset: {asset}".format(asset=asset_id))
+    print("Retrieving all metadata for the asset: {asset}".format(asset=asset_id))
+    
+    cursor = None
+    
+    more_results = True
+    while more_results:
+        retrieve_metadata_response = api.get_all_metadata(asset_id, cursor)
+        assert retrieve_metadata_response.status_code == 200
+        retrieved_metadata = retrieve_metadata_response.json()
+        print(retrieved_metadata)
+        if "cursor" in retrieved_metadata:
+            cursor = retrieved_metadata["cursor"]
+        else:
+            more_results = False
+    print("Successfully retrieved all metadata for asset: {asset}".format(asset=asset_id))
 
     # Retrieve specific metadata from the asset
 


### PR DESCRIPTION
*Issue #, if available:* #285

*Description of changes:*

The GET /metadata/asset/metadata API to request all metadata for a specific asset was fixed with #299.  This change enables the failing test for that method.  I had to change the code for the test slightly to pass query parameters to the requests api using a parameter rather than the url.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
