### PR TITLE
fix operator timeouts

### DIFF
--- a/source/operators/operator-library.yaml
+++ b/source/operators/operator-library.yaml
@@ -1332,6 +1332,7 @@ Resources:
             ],
           ]
       Runtime: "python3.8"
+      Timeout: 120
       Environment:
         Variables:
           REKOGNITION_SNS_TOPIC_ARN: !Ref "snsRekognitionTopic"
@@ -1397,6 +1398,7 @@ Resources:
             ],
           ]
       Runtime: "python3.8"
+      Timeout: 120
       Environment:
         Variables:
           REKOGNITION_SNS_TOPIC_ARN: !Ref "snsRekognitionTopic"
@@ -1462,6 +1464,7 @@ Resources:
             ],
           ]
       Runtime: "python3.8"
+      Timeout: 120
       Environment:
         Variables:
           REKOGNITION_SNS_TOPIC_ARN: !Ref "snsRekognitionTopic"
@@ -1652,6 +1655,7 @@ Resources:
             ],
           ]
       Runtime: "python3.8"
+      Timeout: 120
       Environment:
         Variables:
           DataplaneEndpoint: !Ref "DataPlaneEndpoint"
@@ -2016,6 +2020,7 @@ Resources:
             ],
           ]
       Runtime: "python3.8"
+      Timeout: 120
       Environment:
         Variables:
           DataplaneEndpoint: !Ref "DataPlaneEndpoint"
@@ -2045,6 +2050,7 @@ Resources:
             ],
           ]
       Runtime: "python3.8"
+      Timeout: 120
       Environment:
         Variables:
           DataplaneEndpoint: !Ref "DataPlaneEndpoint"


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/aws-media-insights-engine/issues/401

*Description of changes:*

Some of the operator lambdas were still using the default 3s lambda timeout. That's too short and will cause workflows to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
