### PR TITLE
fix scheduled_workflow

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -36,12 +36,7 @@ jobs:
           TEMPLATE_OUTPUT_BUCKET=mie-dev-us-west-2
           ./build-s3-dist.sh --no-layer --template-bucket $TEMPLATE_OUTPUT_BUCKET --code-bucket $DIST_OUTPUT_BUCKET --version $VERSION --region $REGION
           read -r TEMPLATE < templateUrl.txt
-          aws cloudformation create-stack --stack-name $MIE_STACK_NAME --template-url $TEMPLATE --region $REGION --parameters ParameterKey=DeployTestResources,ParameterValue=true ParameterKey=MaxConcurrentWorkflows,ParameterValue=10 ParameterKey=DeployAnalyticsPipeline,ParameterValue=true ParameterKey=EnableXrayTrace,ParameterValue=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --disable-rollback
-
-      - name: Wait for deploy to complete before progressing
-        uses: jakejarvis/wait-action@master
-        with:
-          time: '10m'
+          aws cloudformation deploy --stack-name $MIE_STACK_NAME --region $REGION --template-file global-s3-assets/media-insights-stack.template --s3-bucket $DIST_OUTPUT_BUCKET-$REGION --s3-prefix media_insights_engine/$VERSION --parameter-overrides DeployTestResources=true MaxConcurrentWorkflows=10 DeployAnalyticsPipeline=true EnableXrayTrace=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --force-upload
 
   test-us-west-2:
     needs: build-us-west-2
@@ -80,9 +75,6 @@ jobs:
 
       - name: Run integ tests
         run: |
-          status=$(aws cloudformation describe-stacks --stack-name $MIE_STACK_NAME --region $MIE_REGION --output json --query 'Stacks[0].StackStatus' | tr -d '"')
-          while [ "$status" == *"IN_PROGRESS" ]; do sleep 5; status=$(aws cloudformation describe-stacks --stack-name $MIE_STACK_NAME --region $MIE_REGION --output json --query 'Stacks[0].StackStatus' | tr -d '"'); done
-          echo "$MIE_STACK_NAME stack status: $stack_status"
           cd $GITHUB_WORKSPACE
           cd test/integ
           ./run_integ.sh

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -80,6 +80,9 @@ jobs:
 
       - name: Run integ tests
         run: |
+          status=$(aws cloudformation describe-stacks --stack-name $MIE_STACK_NAME --region $MIE_REGION --output json --query 'Stacks[0].StackStatus' | tr -d '"')
+          while [ "$status" == *"IN_PROGRESS" ]; do sleep 5; status=$(aws cloudformation describe-stacks --stack-name $MIE_STACK_NAME --region $MIE_REGION --output json --query 'Stacks[0].StackStatus' | tr -d '"'); done
+          echo "$MIE_STACK_NAME stack status: $stack_status"
           cd $GITHUB_WORKSPACE
           cd test/integ
           ./run_integ.sh

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -56,11 +56,7 @@ jobs:
           TEMPLATE_OUTPUT_BUCKET=mie-dev-$REGION
           ./build-s3-dist.sh --no-layer --template-bucket $TEMPLATE_OUTPUT_BUCKET --code-bucket $DIST_OUTPUT_BUCKET --version $VERSION --region $REGION
           read -r TEMPLATE < templateUrl.txt
-          aws cloudformation create-stack --stack-name $MIE_STACK_NAME --template-url $TEMPLATE --region $REGION --parameters ParameterKey=DeployTestResources,ParameterValue=true ParameterKey=MaxConcurrentWorkflows,ParameterValue=10 ParameterKey=DeployAnalyticsPipeline,ParameterValue=true ParameterKey=EnableXrayTrace,ParameterValue=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --disable-rollback
-      - name: Wait for deploy to complete before progressing
-        uses: jakejarvis/wait-action@master
-        with:
-          time: '10m'
+          aws cloudformation deploy --stack-name $MIE_STACK_NAME --region $REGION --template-file global-s3-assets/media-insights-stack.template --s3-bucket $DIST_OUTPUT_BUCKET-$REGION --s3-prefix media_insights_engine/$VERSION --parameter-overrides DeployTestResources=true MaxConcurrentWorkflows=10 DeployAnalyticsPipeline=true EnableXrayTrace=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --force-upload
 
   build-us-east-1:
     needs: create-release-branch
@@ -88,11 +84,7 @@ jobs:
           TEMPLATE_OUTPUT_BUCKET=mie-dev-$REGION
           ./build-s3-dist.sh --no-layer --template-bucket $TEMPLATE_OUTPUT_BUCKET --code-bucket $DIST_OUTPUT_BUCKET --version $VERSION --region $REGION
           read -r TEMPLATE < templateUrl.txt
-          aws cloudformation create-stack --stack-name $MIE_STACK_NAME --template-url $TEMPLATE --region $REGION --parameters ParameterKey=DeployTestResources,ParameterValue=true ParameterKey=MaxConcurrentWorkflows,ParameterValue=10 ParameterKey=DeployAnalyticsPipeline,ParameterValue=true ParameterKey=EnableXrayTrace,ParameterValue=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --disable-rollback
-      - name: Wait for deploy to complete before progressing
-        uses: jakejarvis/wait-action@master
-        with:
-          time: '10m'
+          aws cloudformation deploy --stack-name $MIE_STACK_NAME --region $REGION --template-file global-s3-assets/media-insights-stack.template --s3-bucket $DIST_OUTPUT_BUCKET-$REGION --s3-prefix media_insights_engine/$VERSION --parameter-overrides DeployTestResources=true MaxConcurrentWorkflows=10 DeployAnalyticsPipeline=true EnableXrayTrace=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --force-upload
 
   test-us-west-2:
     needs: build-us-west-2

--- a/.github/workflows/scheduled-workflow.yml
+++ b/.github/workflows/scheduled-workflow.yml
@@ -100,6 +100,6 @@ jobs:
         with:
           title: Nightly test for $SHORT_SHA Failed
           token: ${{secrets.GITHUB_TOKEN}}
-          assignees: [brandold, ianwow, aburkleaux-amazon]
+          assignees: ianwow
           labels: bug
           body: Nightly test failed for commit ${{github.sha}}

--- a/.github/workflows/scheduled-workflow.yml
+++ b/.github/workflows/scheduled-workflow.yml
@@ -84,6 +84,10 @@ jobs:
 
       - name: Run integ tests
         run: |
+          # Wait for stack to finish deploying
+          status=$(aws cloudformation describe-stacks --stack-name $MIE_STACK_NAME --region $MIE_REGION --output json --query 'Stacks[0].StackStatus' | tr -d '"')
+          while [ "$status" == *"IN_PROGRESS" ]; do sleep 5; status=$(aws cloudformation describe-stacks --stack-name $MIE_STACK_NAME --region $MIE_REGION --output json --query 'Stacks[0].StackStatus' | tr -d '"'); done
+          echo "$MIE_STACK_NAME stack status: $stack_status"
           cd $GITHUB_WORKSPACE
           cd test/integ
           ./run_integ.sh

--- a/.github/workflows/scheduled-workflow.yml
+++ b/.github/workflows/scheduled-workflow.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Initialize AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-            aws-access-key-id: ${{ secrets.BUILD_AWS_ACCESS_KEY_ID }}
-            aws-secret-access-key: ${{ secrets.BUILD_AWS_SECRET_ACCESS_KEY }}
-            aws-region: us-west-2
+          aws-access-key-id: ${{ secrets.BUILD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.BUILD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
 
       - name: Generate short sha
         run: |
@@ -33,7 +33,7 @@ jobs:
           DIST_OUTPUT_BUCKET=mie-dev
           TEMPLATE_OUTPUT_BUCKET=mie-dev-us-west-2
           ./build-s3-dist.sh --no-layer --template-bucket $TEMPLATE_OUTPUT_BUCKET --code-bucket $DIST_OUTPUT_BUCKET --version $VERSION --region $REGION
-          aws cloudformation deploy --stack-name $MIE_STACK_NAME --template-file global-s3-assets/media-insights-stack.template --s3-bucket $DIST_OUTPUT_BUCKET-$REGION --s3-prefix media_insights_engine/$VERSION --parameter-overrides DeployTestResources=true MaxConcurrentWorkflows=10 DeployAnalyticsPipeline=true EnableXrayTrace=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --force-upload
+          aws cloudformation deploy --stack-name $MIE_STACK_NAME --region $REGION --template-file global-s3-assets/media-insights-stack.template --s3-bucket $DIST_OUTPUT_BUCKET-$REGION --s3-prefix media_insights_engine/$VERSION --parameter-overrides DeployTestResources=true MaxConcurrentWorkflows=10 DeployAnalyticsPipeline=true EnableXrayTrace=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --force-upload
 
       - name: Build Failed
         if: ${{ failure() }}
@@ -41,7 +41,7 @@ jobs:
         with:
           title: Nightly build for $SHORT_SHA Failed
           token: ${{secrets.GITHUB_TOKEN}}
-          assignees: brandold, ianwow, aburkleaux-amazon
+          assignees: ianwow
           labels: bug
           body: Nightly build failed for commit ${{github.sha}}
 
@@ -61,9 +61,9 @@ jobs:
       - name: Initialize AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-            aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
-            aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
-            aws-region: us-west-2
+          aws-access-key-id: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
 
       - name: Generate short sha
         run: |
@@ -73,7 +73,7 @@ jobs:
         uses: stelligent/cfn_nag@master
         continue-on-error: true
         with:
-            input_path: deployment
+          input_path: deployment
 
       - name: Run unit tests
         run: |
@@ -84,10 +84,6 @@ jobs:
 
       - name: Run integ tests
         run: |
-          # Wait for stack to finish deploying
-          status=$(aws cloudformation describe-stacks --stack-name $MIE_STACK_NAME --region $MIE_REGION --output json --query 'Stacks[0].StackStatus' | tr -d '"')
-          while [ "$status" == *"IN_PROGRESS" ]; do sleep 5; status=$(aws cloudformation describe-stacks --stack-name $MIE_STACK_NAME --region $MIE_REGION --output json --query 'Stacks[0].StackStatus' | tr -d '"'); done
-          echo "$MIE_STACK_NAME stack status: $stack_status"
           cd $GITHUB_WORKSPACE
           cd test/integ
           ./run_integ.sh


### PR DESCRIPTION
*Issue #, if available:*

Closes #405 

*Description of changes:*

There are 2 problems with the schedule-workflow:

- It needs to wait to run the integration test until the stack is fully deployed. I fixed this by polling the stack status before running in the integration test.
- "Invalid yaml error" in the assignee field for issues generated in response to a workflow failure. I fixed this by just changing it from a list to a single user.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
