### PR TITLE
allow_scheduled_workflow_to_be_manually_triggered

### DIFF
--- a/.github/workflows/scheduled-workflow.yml
+++ b/.github/workflows/scheduled-workflow.yml
@@ -3,6 +3,7 @@ name: scheduled-workflow
 on:
   schedule:
     - cron: '0 4 * * *'
+  workflow_dispatch:
 
 jobs:
   build-us-west-2:


### PR DESCRIPTION
*Issue #, if available:*

none

*Description of changes:*

We need to be able to trigger the scheduled workflow manually in order to effectively troubleshoot it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
