### PR TITLE
wait longer for workflow to delete

### DIFF
--- a/test/e2e/test_complete_workflow.py
+++ b/test/e2e/test_complete_workflow.py
@@ -148,6 +148,8 @@ def test_workflow_execution(workflow_api, dataplane_api, stack_resources, testin
 
     delete_workflow_request = workflow_api.delete_workflow_request(test_workflow["Name"])
     assert delete_workflow_request.status_code == 200
+    # Wait for the workflow to delete. It can take several seconds.
+    time.sleep(30)
 
     # Delete stages
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The dataplane e2e test keeps failing because it doesn't wait long enough after removing workflows left over from previous tests. Hopefully this fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
