### PR TITLE
use solution builder's convention for s3 bucket names

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -36,7 +36,7 @@ jobs:
           TEMPLATE_OUTPUT_BUCKET=mie-dev-us-west-2
           ./build-s3-dist.sh --no-layer --template-bucket $TEMPLATE_OUTPUT_BUCKET --code-bucket $DIST_OUTPUT_BUCKET --version $VERSION --region $REGION
           read -r TEMPLATE < templateUrl.txt
-          aws cloudformation deploy --stack-name $MIE_STACK_NAME --region $REGION --template-file global-s3-assets/media-insights-stack.template --s3-bucket $DIST_OUTPUT_BUCKET-$REGION --s3-prefix media_insights_engine/$VERSION --parameter-overrides DeployTestResources=true MaxConcurrentWorkflows=10 DeployAnalyticsPipeline=true EnableXrayTrace=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --force-upload
+          aws cloudformation deploy --stack-name $MIE_STACK_NAME --region $REGION --template-file global-s3-assets/media-insights-stack.template --s3-bucket $DIST_OUTPUT_BUCKET-$REGION --s3-prefix aws-media-insights-engine/$VERSION --parameter-overrides DeployTestResources=true MaxConcurrentWorkflows=10 DeployAnalyticsPipeline=true EnableXrayTrace=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --force-upload
 
   test-us-west-2:
     needs: build-us-west-2

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -56,7 +56,7 @@ jobs:
           TEMPLATE_OUTPUT_BUCKET=mie-dev-$REGION
           ./build-s3-dist.sh --no-layer --template-bucket $TEMPLATE_OUTPUT_BUCKET --code-bucket $DIST_OUTPUT_BUCKET --version $VERSION --region $REGION
           read -r TEMPLATE < templateUrl.txt
-          aws cloudformation deploy --stack-name $MIE_STACK_NAME --region $REGION --template-file global-s3-assets/media-insights-stack.template --s3-bucket $DIST_OUTPUT_BUCKET-$REGION --s3-prefix media_insights_engine/$VERSION --parameter-overrides DeployTestResources=true MaxConcurrentWorkflows=10 DeployAnalyticsPipeline=true EnableXrayTrace=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --force-upload
+          aws cloudformation deploy --stack-name $MIE_STACK_NAME --region $REGION --template-file global-s3-assets/media-insights-stack.template --s3-bucket $DIST_OUTPUT_BUCKET-$REGION --s3-prefix aws-media-insights-engine/$VERSION --parameter-overrides DeployTestResources=true MaxConcurrentWorkflows=10 DeployAnalyticsPipeline=true EnableXrayTrace=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --force-upload
 
   build-us-east-1:
     needs: create-release-branch
@@ -84,7 +84,7 @@ jobs:
           TEMPLATE_OUTPUT_BUCKET=mie-dev-$REGION
           ./build-s3-dist.sh --no-layer --template-bucket $TEMPLATE_OUTPUT_BUCKET --code-bucket $DIST_OUTPUT_BUCKET --version $VERSION --region $REGION
           read -r TEMPLATE < templateUrl.txt
-          aws cloudformation deploy --stack-name $MIE_STACK_NAME --region $REGION --template-file global-s3-assets/media-insights-stack.template --s3-bucket $DIST_OUTPUT_BUCKET-$REGION --s3-prefix media_insights_engine/$VERSION --parameter-overrides DeployTestResources=true MaxConcurrentWorkflows=10 DeployAnalyticsPipeline=true EnableXrayTrace=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --force-upload
+          aws cloudformation deploy --stack-name $MIE_STACK_NAME --region $REGION --template-file global-s3-assets/media-insights-stack.template --s3-bucket $DIST_OUTPUT_BUCKET-$REGION --s3-prefix aws-media-insights-engine/$VERSION --parameter-overrides DeployTestResources=true MaxConcurrentWorkflows=10 DeployAnalyticsPipeline=true EnableXrayTrace=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --force-upload
 
   test-us-west-2:
     needs: build-us-west-2

--- a/.github/workflows/scheduled-workflow.yml
+++ b/.github/workflows/scheduled-workflow.yml
@@ -34,7 +34,7 @@ jobs:
           DIST_OUTPUT_BUCKET=mie-dev
           TEMPLATE_OUTPUT_BUCKET=mie-dev-us-west-2
           ./build-s3-dist.sh --no-layer --template-bucket $TEMPLATE_OUTPUT_BUCKET --code-bucket $DIST_OUTPUT_BUCKET --version $VERSION --region $REGION
-          aws cloudformation deploy --stack-name $MIE_STACK_NAME --region $REGION --template-file global-s3-assets/media-insights-stack.template --s3-bucket $DIST_OUTPUT_BUCKET-$REGION --s3-prefix media_insights_engine/$VERSION --parameter-overrides DeployTestResources=true MaxConcurrentWorkflows=10 DeployAnalyticsPipeline=true EnableXrayTrace=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --force-upload
+          aws cloudformation deploy --stack-name $MIE_STACK_NAME --region $REGION --template-file global-s3-assets/media-insights-stack.template --s3-bucket $DIST_OUTPUT_BUCKET-$REGION --s3-prefix aws-media-insights-engine/$VERSION --parameter-overrides DeployTestResources=true MaxConcurrentWorkflows=10 DeployAnalyticsPipeline=true EnableXrayTrace=true ParameterKey=SendAnonymousData,ParameterValue=false --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --force-upload
 
       - name: Build Failed
         if: ${{ failure() }}

--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -758,11 +758,11 @@ echo "Copy dist to S3"
 echo "------------------------------------------------------------------------------"
 cd "$build_dir"/ || exit 1
 echo "Copying the prepared distribution to:"
-echo "s3://$global_bucket/media_insights_engine/$version/"
-echo "s3://${regional_bucket}-${region}/media_insights_engine/$version/"
+echo "s3://$global_bucket/aws-media-insights-engine/$version/"
+echo "s3://${regional_bucket}-${region}/aws-media-insights-engine/$version/"
 set -x
-aws s3 sync $global_dist_dir s3://$global_bucket/media_insights_engine/$version/
-aws s3 sync $regional_dist_dir s3://${regional_bucket}-${region}/media_insights_engine/$version/
+aws s3 sync $global_dist_dir s3://$global_bucket/aws-media-insights-engine/$version/
+aws s3 sync $regional_dist_dir s3://${regional_bucket}-${region}/aws-media-insights-engine/$version/
 set +x
 
 echo "------------------------------------------------------------------------------"
@@ -771,11 +771,11 @@ echo "--------------------------------------------------------------------------
 
 echo ""
 echo "Template to deploy:"
-echo "TEMPLATE='"https://"$global_bucket"."$s3domain"/media_insights_engine/"$version"/media-insights-stack.template"'"
+echo "TEMPLATE='"https://"$global_bucket"."$s3domain"/aws-media-insights-engine/"$version"/media-insights-stack.template"'"
 
 # Save the template URI for test automation scripts:
 touch templateUrl.txt
-echo "https://"$global_bucket"."$s3domain"/media_insights_engine/"$version"/media-insights-stack.template" > templateUrl.txt
+echo "https://"$global_bucket"."$s3domain"/aws-media-insights-engine/"$version"/media-insights-stack.template" > templateUrl.txt
 
 cleanup
 echo "Done"

--- a/deployment/media-insights-dataplane-streaming-stack.template
+++ b/deployment/media-insights-dataplane-streaming-stack.template
@@ -19,7 +19,7 @@ Mappings:
   SourceCode:
     General:
       RegionalS3Bucket: "%%REGIONAL_BUCKET_NAME%%"
-      CodeKeyPrefix: "media_insights_engine/%%VERSION%%"
+      CodeKeyPrefix: "aws-media-insights-engine/%%VERSION%%"
 
 Resources:
 # kinesis data stream

--- a/deployment/media-insights-stack.yaml
+++ b/deployment/media-insights-stack.yaml
@@ -22,7 +22,7 @@ Parameters:
     Default: 5
     MinValue: 1
   EnableXrayTrace:
-    Description: Enable Active Xray tracing on all entry points to the stack
+    Description: Turn on Xray tracing on all entry points to the stack
     Type: String
     Default: No
     AllowedValues:
@@ -63,8 +63,8 @@ Mappings:
     General:
       GlobalS3Bucket: "%%GLOBAL_BUCKET_NAME%%"
       RegionalS3Bucket: "%%REGIONAL_BUCKET_NAME%%"
-      CodeKeyPrefix: "media_insights_engine/%%VERSION%%"
-      TemplateKeyPrefix: "media_insights_engine/%%VERSION%%"
+      CodeKeyPrefix: "aws-media-insights-engine/%%VERSION%%"
+      TemplateKeyPrefix: "aws-media-insights-engine/%%VERSION%%"
       FrameworkVersion: "%%VERSION%%"
 
 Resources:
@@ -822,7 +822,6 @@ Resources:
           - id: W51
             reason: "Bucket is private and does not need a bucket policy"
 
-  # TODO: Update cors config per: https://docs.amplify.aws/lib/storage/getting-started/q/platform/js#using-amazon-s3
   Dataplane:
     Type: "AWS::S3::Bucket"
     DependsOn: DataplaneLogsBucket
@@ -1663,7 +1662,6 @@ Resources:
       Version: !FindInMap ["SourceCode", "General", "FrameworkVersion"]
 
 Outputs:
-  # TODO: Add outputs for rest api IDs of workflow/dataplane apis
   OperatorLibraryStack:
     Description: Nested cloudformation stack that contains the MIE operator library
     Value: !GetAtt OperatorLibrary.Outputs.StackName

--- a/deployment/media-insights-test-operations-stack.yaml
+++ b/deployment/media-insights-test-operations-stack.yaml
@@ -20,7 +20,7 @@ Mappings:
     SourceCode:
         General:
             RegionalS3Bucket: "%%REGIONAL_BUCKET_NAME%%"
-            CodeKeyPrefix: "media_insights_engine/%%VERSION%%"
+            CodeKeyPrefix: "aws-media-insights-engine/%%VERSION%%"
 
 Resources:
 

--- a/source/operators/operator-library.yaml
+++ b/source/operators/operator-library.yaml
@@ -5,7 +5,7 @@ Mappings:
   SourceCode:
     General:
       RegionalS3Bucket: "%%REGIONAL_BUCKET_NAME%%"
-      CodeKeyPrefix: "media_insights_engine/%%VERSION%%"
+      CodeKeyPrefix: "aws-media-insights-engine/%%VERSION%%"
 
 Parameters:
   DataPlaneEndpoint:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Address the fact that the solution builder pipeline requires that we use a different name convention for s3 buckets. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
