### PR TITLE
show collection id parameter in the default configuration for facesearch

### DIFF
--- a/source/operators/operator-library.yaml
+++ b/source/operators/operator-library.yaml
@@ -2288,7 +2288,7 @@ Resources:
       ResourceType: "Operation"
       Name: "GenericDataLookup"
       Type: "Sync"
-      Configuration: { "MediaType": "Video", "Enabled": true }
+      Configuration: { "MediaType": "Video", "Enabled": false }
       StartLambdaArn: !GetAtt startGenericDataLookup.Arn
 
   MediainfoOperation:
@@ -2298,7 +2298,7 @@ Resources:
       ResourceType: "Operation"
       Name: "Mediainfo"
       Type: "Sync"
-      Configuration: { "MediaType": "Video", "Enabled": true }
+      Configuration: { "MediaType": "Video", "Enabled": false }
       StartLambdaArn: !GetAtt Mediainfo.Arn
 
   MediainfoOperationImage:
@@ -2566,7 +2566,7 @@ Resources:
       ResourceType: "Operation"
       Name: "faceSearch"
       Type: "Async"
-      Configuration: { "MediaType": "Video", "Enabled": true }
+      Configuration: { "MediaType": "Video", "Enabled": false, "CollectionId": "" }
       StartLambdaArn: !GetAtt startFaceSearch.Arn
       MonitorLambdaArn: !GetAtt checkFaceSearch.Arn
 
@@ -2577,7 +2577,7 @@ Resources:
       ResourceType: "Operation"
       Name: "faceSearchImage"
       Type: "Sync"
-      Configuration: { "MediaType": "Image", "Enabled": true }
+      Configuration: { "MediaType": "Image", "Enabled": false, "CollectionId": "" }
       StartLambdaArn: !GetAtt startFaceSearch.Arn
 
   labelDetectionOperation:

--- a/source/workflowapi/app.py
+++ b/source/workflowapi/app.py
@@ -501,7 +501,7 @@ TASK_PARAMETERS_ASL = {
     "StageName.$": "$.Name",
     "Name":"%%OPERATION_NAME%%",
     "Input.$":"$.Input",
-    "Configuration.$":"$.Configuration.%%OPERATION_NAME%%",
+    "g.$":"$.Configuration.%%OPERATION_NAME%%",
     "AssetId.$":"$.AssetId",
     "WorkflowExecutionId.$":"$.WorkflowExecutionId"
 }
@@ -2970,7 +2970,7 @@ def operation_resource(event, context):
         operation = event["ResourceProperties"]
 
         # boolean type comes in as text from cloudformation - must decode string or take string for anabled parameter
-        operation["Configuration"]["Enabled"] = bool(operation["Configuration"]["Enabled"])
+        operation["Configuration"]["Enabled"] = True if operation["Configuration"]["Enabled"] == 'true' else False
         operation = create_operation(operation)
         send_response(event, context, "SUCCESS",
                       {"Message": "Resource creation successful!", "Name": event["ResourceProperties"]["Name"],

--- a/source/workflowapi/app.py
+++ b/source/workflowapi/app.py
@@ -496,16 +496,6 @@ def create_operation(operation):
     logger.info("end create_operation: {}".format(json.dumps(operation, cls=DecimalEncoder)))
     return operation
 
-# FIXME - dead code?
-TASK_PARAMETERS_ASL = {
-    "StageName.$": "$.Name",
-    "Name":"%%OPERATION_NAME%%",
-    "Input.$":"$.Input",
-    "g.$":"$.Configuration.%%OPERATION_NAME%%",
-    "AssetId.$":"$.AssetId",
-    "WorkflowExecutionId.$":"$.WorkflowExecutionId"
-}
-
 ASYNC_OPERATION_ASL =         {
     "StartAt": "Filter %%OPERATION_NAME%% Media Type? (%%STAGE_NAME%%)",
     "States": {


### PR DESCRIPTION
*Issue #, if available:*

 #456, #458

*Description of changes:*

The default configuration for workflows should work, but they don't because facesearch is enabled without a corresponding face collection. Since we can't know what face collections a user might have, we should disable facesearch by default. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
