### PR TITLE
Raise file-not-found errors

### DIFF
--- a/source/workflowapi/app.py
+++ b/source/workflowapi/app.py
@@ -1939,15 +1939,22 @@ def create_workflow_execution(trigger, workflow_execution):
                 raise ChaliceViewError("Exception '%s'" % e)
             else:
                 asset_creation = dataplane.create_asset(s3bucket, s3key)
-                asset_input = {
-                    "Media": {
-                        media_type: {
-                            "S3Bucket": asset_creation["S3Bucket"],
-                            "S3Key": asset_creation["S3Key"]
+                # If create_asset fails, then asset_creation will contain the error
+                # string instead of the expected dict. So, we'll raise that error
+                # if we get a KeyError in the following try block:
+                try:
+                    asset_input = {
+                        "Media": {
+                            media_type: {
+                                "S3Bucket": asset_creation["S3Bucket"],
+                                "S3Key": asset_creation["S3Key"]
+                            }
                         }
                     }
-                }
-                asset_id = asset_creation["AssetId"]
+                    asset_id = asset_creation["AssetId"]
+                except KeyError as e:
+                    logger.error("Error creating asset {}".format(asset_creation))
+                    raise ChaliceViewError("Error creating asset '%s'" % asset_creation)
         else:
 
             try:


### PR DESCRIPTION
*Issue #, if available:*

Closes #505 

*Description of changes:*

When a workflow input references a file that does not exist, the workflow will fail with an unclear error. This PR makes the error explain a little more about why the workflow failed.

Here is the error that users will now see if they provide an invalid path to input media file:

```
'{"Code":"ChaliceViewError","Message":"ChaliceViewError: Exception \'ChaliceViewError: Error creating asset \'{\'Code\': \'ChaliceViewError\', \'Message\': \'ChaliceViewError: Unable to move uploaded media to the dataplane bucket: The specified key does not exist.\'}\'\'"}'
```

The old error was this one:

```
{"Code":"ChaliceViewError","Message":"ChaliceViewError: Exception \'\'S3Bucket\'\'"}'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
