### PR TITLE
Skip polly and add a warning if input text is too long

### DIFF
--- a/source/operators/captions/webcaptions.py
+++ b/source/operators/captions/webcaptions.py
@@ -879,9 +879,6 @@ def start_polly_webcaptions (event, context):
                     caption["PollyStatus"] = "not supported"
                 else:
                     raise
-            # except polly.Client.exceptions.TextLengthExceededException as e:
-            #     caption["PollyMessage"] = "WARNING: Polly.Client.exceptions.TextLengthExceededException"
-            #     caption["PollyStatus"] = "not supported"
             except Exception as e:
                 operator_object.update_workflow_status("Error")
                 operator_object.add_workflow_metadata(PollyCollectionError="Unable to get response from polly: {e}".format(e=str(e)))

--- a/source/workflowapi/app.py
+++ b/source/workflowapi/app.py
@@ -2729,7 +2729,7 @@ def create_terminology():
 
     Returns:
         This is a proxy for boto3 create_vocabulary and returns the output from that SDK method.
-        See `the boto3 documentation for details <htatps://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/translate.html#TranslateService.Client.create_terminology>`_
+        See `the boto3 documentation for details <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/translate.html#TranslateService.Client.create_terminology>`_
 
     Raises:
         See the boto3 documentation for details

--- a/source/workflowapi/app.py
+++ b/source/workflowapi/app.py
@@ -2729,7 +2729,7 @@ def create_terminology():
 
     Returns:
         This is a proxy for boto3 create_vocabulary and returns the output from that SDK method.
-        See `the boto3 documentation for details <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/translate.html#TranslateService.Client.create_terminology>`_
+        See `the boto3 documentation for details <htatps://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/translate.html#TranslateService.Client.create_terminology>`_
 
     Raises:
         See the boto3 documentation for details
@@ -2773,13 +2773,11 @@ def get_parallel_data():
     print('get_parallel_data request: '+app.current_request.raw_body.decode())
     translate_client = boto3.client('translate', region_name=os.environ['AWS_REGION'])
     parallel_data_name = json.loads(app.current_request.raw_body.decode())['parallel_data_name']
-    response = translate_client.get_parallel_data(Name=parallel_data_name, parallel_dataDataFormat='CSV')
-    # Remove response metadata since we don't need it
-    if 'RespnseMetadata' in response:
-        del response['ResponseMetadata']
+    response = translate_client.get_parallel_data(Name=parallel_data_name)
+    
     # Convert time field to a format that is JSON serializable
-    response['TerminologyProperties']['CreatedAt'] = response['TerminologyProperties']['CreatedAt'].isoformat()
-    response['TerminologyProperties']['LastUpdatedAt'] = response['TerminologyProperties']['LastUpdatedAt'].isoformat()
+    response['ParallelDataProperties']['CreatedAt'] = response['ParallelDataProperties']['CreatedAt'].isoformat()
+    response['ParallelDataProperties']['LastUpdatedAt'] = response['ParallelDataProperties']['LastUpdatedAt'].isoformat()
     return response
 
 
@@ -2797,7 +2795,7 @@ def download_parallel_data():
 
 
     Returns:
-        A string contining the CSV formatted Amazon Transcribe parallel_data
+        A pre-signed url for the the CSV formatted Amazon Transcribe parallel_data
 
         .. code-block:: python
 
@@ -2813,7 +2811,7 @@ def download_parallel_data():
     print('download_parallel_data request: '+app.current_request.raw_body.decode())
     translate_client = boto3.client('translate', region_name=os.environ['AWS_REGION'])
     parallel_data_name = json.loads(app.current_request.raw_body.decode())['parallel_data_name']
-    url = translate_client.get_parallel_data(Name=parallel_data_name, ParallelDataFormat='CSV')['ParallelDataLocation']['Location']
+    url = translate_client.get_parallel_data(Name=parallel_data_name)['DataLocation']['Location']
     import urllib.request
     parallel_data_csv = urllib.request.urlopen(url).read().decode("utf-8")
     return {"parallel_data_csv": parallel_data_csv}
@@ -2888,7 +2886,7 @@ def create_parallel_data():
 
         {
             'parallel_data_name'='string',
-            'parallel_data_csv='string'
+            'parallel_data_s3uri='string'
         }
 
 
@@ -2904,14 +2902,12 @@ def create_parallel_data():
     print('create_parallel_data request: '+app.current_request.raw_body.decode())
     translate_client = boto3.client('translate', region_name=os.environ['AWS_REGION'])
     parallel_data_name = json.loads(app.current_request.raw_body.decode())['parallel_data_name']
-    parallel_data_csv = json.loads(app.current_request.raw_body.decode())['parallel_data_csv']
-    response = translate_client.import_parallel_data(
+    parallel_data_s3uri = json.loads(app.current_request.raw_body.decode())['parallel_data_s3uri']
+    response = translate_client.create_parallel_data(
         Name=parallel_data_name,
-        MergeStrategy='OVERWRITE',
-        ParallelData={'File': parallel_data_csv, 'Format':'CSV'}
+        ParallelDataConfig={'S3Uri': parallel_data_s3uri, 'Format':'CSV'}
     )
-    response['ParallelDataProperties']['CreatedAt'] = response['ParallelDataProperties']['CreatedAt'].isoformat()
-    response['ParallelDataProperties']['LastUpdatedAt'] = response['ParallelDataProperties']['LastUpdatedAt'].isoformat()
+    
     return response
 
 # ================================================================================================

--- a/source/workflowapi/external_resources.json
+++ b/source/workflowapi/external_resources.json
@@ -207,10 +207,12 @@
                 {
                   "Effect": "Allow",
                   "Action": [
+                    "translate:CreateTerminology",
                     "translate:DeleteTerminology",
                     "translate:GetTerminology",
                     "translate:ImportTerminology",
                     "translate:ListTerminologies",
+                    "translate:CreateParallelData",
                     "translate:DeleteParallelData",
                     "translate:GetParallelData",
                     "translate:ImportParallelData",

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -9,6 +9,7 @@ import requests
 import logging
 import re
 import os
+import time
 from requests_aws4auth import AWS4Auth
 
 
@@ -27,6 +28,8 @@ def testing_env_variables():
             'SAMPLE_TEXT': os.environ['TEST_TEXT'],
             'SAMPLE_JSON': os.environ['TEST_JSON'],
             'SAMPLE_FACE_IMAGE': os.environ['TEST_FACE_IMAGE'],
+            'SAMPLE_PARALLEL_DATA': os.environ['TEST_PARALLEL_DATA'],
+            'SAMPLE_TERMINOLOGY': os.environ['TEST_TERMINOLOGY'],
             'REGION': os.environ['MIE_REGION'],
             'MIE_STACK_NAME': os.environ['MIE_STACK_NAME'],
             'FACE_COLLECTION_ID': os.environ['TEST_FACE_COLLECTION_ID'],
@@ -69,7 +72,7 @@ def stack_resources(testing_env_variables):
     for output in outputs:
         resources[output["OutputKey"]] = output["OutputValue"]
 
-    expected_resources = ['WorkflowApiRestID', 'DataplaneBucket', 'WorkflowCustomResourceArn', 'TestStack',
+    expected_resources = ['WorkflowApiRestID', 'DataplaneBucket', 'WorkflowCustomResourceArn', 
                           'MediaInsightsEnginePython38Layer', 'AnalyticsStreamArn', 'DataplaneApiEndpoint',
                           'WorkflowApiEndpoint', 'DataplaneApiRestID', 'OperatorLibraryStack', 'PollyOperation',
                           'ContentModerationOperationImage', 'GenericDataLookupOperation',
@@ -104,6 +107,7 @@ def upload_media(testing_env_variables, stack_resources):
     # s3.upload_file(testing_env_variables['MEDIA_PATH'] + testing_env_variables['SAMPLE_IMAGE'], stack_resources['DataplaneBucket'], 'upload/' + testing_env_variables['SAMPLE_IMAGE'])
     # s3.upload_file(testing_env_variables['MEDIA_PATH'] + testing_env_variables['SAMPLE_FACE_IMAGE'], stack_resources['DataplaneBucket'], 'upload/' + testing_env_variables['SAMPLE_FACE_IMAGE'])
     s3.upload_file(testing_env_variables['MEDIA_PATH'] + testing_env_variables['SAMPLE_VIDEO'], stack_resources['DataplaneBucket'], 'upload/' + testing_env_variables['SAMPLE_VIDEO'])
+    s3.upload_file(testing_env_variables['MEDIA_PATH'] + testing_env_variables['SAMPLE_PARALLEL_DATA'], stack_resources['DataplaneBucket'], 'upload/' + testing_env_variables['SAMPLE_PARALLEL_DATA'])
     # Wait for fixture to go out of scope:
     yield upload_media
 
@@ -167,6 +171,76 @@ class WorkflowAPI:
 
         return get_workflow_execution_response
 
+    def get_terminology(self, body):
+        headers = {"Content-Type": "application/json"}
+        print("POST /service/translate/get_terminology")
+        get_terminology_response = requests.post(self.stack_resources["WorkflowApiEndpoint"]+'/service/translate/get_terminology', headers=headers, json=body, verify=True, auth=self.auth)
+
+        return get_terminology_response
+
+    def download_terminology(self, body):
+        headers = {"Content-Type": "application/json"}
+        print("POST /service/translate/download_terminology")
+        download_terminology_response = requests.post(self.stack_resources["WorkflowApiEndpoint"]+'/service/translate/download_terminology', headers=headers, json=body, verify=True, auth=self.auth)
+
+        return download_terminology_response
+
+    def list_terminologies(self):
+        print("GET /service/translate/list_terminologies")
+        list_terminologies_response = requests.get(self.stack_resources["WorkflowApiEndpoint"]+'/service/translate/list_terminologies', verify=True, auth=self.auth)
+
+        return list_terminologies_response
+
+    def delete_terminology(self, body):
+        headers = {"Content-Type": "application/json"}
+        print("POST /service/translate/delete_terminology")
+        delete_terminology_response = requests.post(self.stack_resources["WorkflowApiEndpoint"]+'/service/translate/delete_terminology', headers=headers, json=body, verify=True, auth=self.auth)
+
+        return delete_terminology_response
+
+    def create_terminology(self, body):
+        headers = {"Content-Type": "application/json"}
+        print("POST /service/translate/create_terminology")
+        create_terminology_response = requests.post(self.stack_resources["WorkflowApiEndpoint"]+'/service/translate/create_terminology', headers=headers, json=body, verify=True, auth=self.auth)
+
+        return create_terminology_response
+
+    def get_parallel_data(self, body):
+        headers = {"Content-Type": "application/json"}
+        print("POST /service/translate/get_parallel_data")
+        get_parallel_data_response = requests.post(self.stack_resources["WorkflowApiEndpoint"]+'/service/translate/get_parallel_data', headers=headers, json=body, verify=True, auth=self.auth)
+
+        return get_parallel_data_response
+
+    def list_parallel_data(self):
+        print("GET /service/translate/list_parallel_data")
+        list_parallel_data_response = requests.get(self.stack_resources["WorkflowApiEndpoint"]+'/service/translate/list_parallel_data', verify=True, auth=self.auth)
+
+        return list_parallel_data_response
+
+    def download_parallel_data(self, body):
+        headers = {"Content-Type": "application/json"}
+        print("POST /service/translate/download_parallel_data")
+        download_parallel_data_response = requests.post(self.stack_resources["WorkflowApiEndpoint"]+'/service/translate/download_parallel_data', headers=headers, json=body, verify=True, auth=self.auth)
+
+        return download_parallel_data_response
+
+
+    def delete_parallel_data(self, body):
+        headers = {"Content-Type": "application/json"}
+        print("POST /service/translate/delete_parallel_data")
+        delete_parallel_data_response = requests.post(self.stack_resources["WorkflowApiEndpoint"]+'/service/translate/delete_parallel_data', headers=headers, json=body, verify=True, auth=self.auth)
+
+        return delete_parallel_data_response
+
+    def create_parallel_data(self, body):
+        headers = {"Content-Type": "application/json"}
+        print("POST /service/translate/create_parallel_data")
+        create_parallel_data_response = requests.post(self.stack_resources["WorkflowApiEndpoint"]+'/service/translate/create_parallel_data', headers=headers, json=body, verify=True, auth=self.auth)
+
+        return create_parallel_data_response
+
+
 # Workflow API Fixture
 
 
@@ -213,3 +287,80 @@ def dataplane_api(stack_resources, testing_env_variables):
         testing_api = DataplaneAPI(stack_resources, testing_env_variables)
         return testing_api
     return _gen_api
+
+
+@pytest.fixture(scope='session')
+def parallel_data(workflow_api, stack_resources, testing_env_variables):
+    workflow_api = workflow_api()
+    parallel_data_s3_uri = 's3://' + \
+        stack_resources['DataplaneBucket'] + '/' + 'upload/' +\
+        testing_env_variables['SAMPLE_PARALLEL_DATA']
+
+    create_parallel_data_body = {
+        "parallel_data_name": testing_env_variables['SAMPLE_PARALLEL_DATA'],
+        "parallel_data_s3uri": parallel_data_s3_uri
+    }
+
+    create_parallel_data_response = workflow_api.create_parallel_data(
+        create_parallel_data_body)
+    assert create_parallel_data_response.status_code == 200
+
+    time.sleep(5)
+
+    # wait for parallel_data to complete
+
+    processing = True
+
+    while processing:
+        body = {'parallel_data_name': testing_env_variables['SAMPLE_PARALLEL_DATA']}
+        get_parallel_data_response = workflow_api.get_parallel_data(body)
+        print(get_parallel_data_response)
+
+        assert get_parallel_data_response.status_code == 200
+
+        response = get_parallel_data_response.json()
+
+        status = response["ParallelDataProperties"]["Status"]
+
+        allowed_statuses = ['CREATING','UPDATING','ACTIVE']
+
+        assert status in allowed_statuses
+
+        if status == "ACTIVE":
+            processing = False
+        else:
+            print('Sleeping for 30 seconds before retrying')
+            time.sleep(30)
+
+    yield create_parallel_data_body
+    
+    delete_parallel_data_body = {
+        "parallel_data_name": testing_env_variables['SAMPLE_PARALLEL_DATA']
+    }
+    delete_parallel_data_response = workflow_api.delete_parallel_data(
+        delete_parallel_data_body)
+    assert delete_parallel_data_response.status_code == 200
+
+@pytest.fixture(scope='session')
+def terminology(workflow_api, dataplane_api, stack_resources, testing_env_variables):
+    workflow_api = workflow_api()
+
+    create_terminology_body = {
+        "terminology_name": testing_env_variables['SAMPLE_TERMINOLOGY'],
+        "terminology_csv": "\"en\",\"es\"\n\"STEEN\",\"STEEN-replaced-by-terminology\""
+    }
+
+    create_terminology_request = workflow_api.create_terminology(
+        create_terminology_body)
+    assert create_terminology_request.status_code == 200
+
+    # wait for terminology to complete - it's synchronous but just in case
+    time.sleep(5)
+
+    yield create_terminology_body
+    delete_terminology_body = {
+        "terminology_name": testing_env_variables['SAMPLE_TERMINOLOGY']
+    }
+    delete_terminology_request = workflow_api.delete_terminology(
+        delete_terminology_body)
+    assert delete_terminology_request.status_code == 200

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -314,7 +314,6 @@ def parallel_data(workflow_api, stack_resources, testing_env_variables):
     while processing:
         body = {'parallel_data_name': testing_env_variables['SAMPLE_PARALLEL_DATA']}
         get_parallel_data_response = workflow_api.get_parallel_data(body)
-        print(get_parallel_data_response)
 
         assert get_parallel_data_response.status_code == 200
 

--- a/test/e2e/run_e2e.sh
+++ b/test/e2e/run_e2e.sh
@@ -74,6 +74,8 @@ export TEST_TEXT="sample-text.txt"
 export TEST_JSON="sample-data.json"
 export TEST_FACE_IMAGE="sample-face.jpg"
 export TEST_FACE_COLLECTION_ID="temporary_face_collection"
+export TEST_PARALLEL_DATA="sampleparalleldata"
+export TEST_TERMINOLOGY="sampleterminology"
 
 # Retrieve exports from mie stack
 #export BUCKET_NAME=`aws cloudformation list-stack-resources --profile default --stack-name $MIE_STACK_NAME --region $REGION --output text --query 'StackResourceSummaries[?LogicalResourceId == \`Dataplane\`]'.PhysicalResourceId`

--- a/test/e2e/test_translate_proxy.py
+++ b/test/e2e/test_translate_proxy.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 ###############################################################################
@@ -48,7 +48,6 @@ def test_parallel_data(workflow_api, testing_env_variables, parallel_data):
 def test_terminology(workflow_api, testing_env_variables, terminology):
     workflow_api = workflow_api()
 
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     
     # Create terminology is done in terminology fixture
 

--- a/test/e2e/test_translate_proxy.py
+++ b/test/e2e/test_translate_proxy.py
@@ -1,0 +1,81 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+###############################################################################
+# Integration testing for the MIE service proxy API for Amazon Translate
+#
+# PRECONDITIONS:
+# MIE base stack must be deployed in your AWS account
+#
+# Boto3 will raise a deprecation warning (known issue). It's safe to ignore.
+#
+# USAGE:
+#   cd tests/
+#   pytest -s -W ignore::DeprecationWarning -p no:cacheprovider
+#
+###############################################################################
+
+import urllib3
+import time
+import json
+
+
+def test_parallel_data(workflow_api, testing_env_variables, parallel_data):
+    workflow_api = workflow_api()
+
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    
+    # Create parallel data is done in parallel_data fixture
+
+    # List parallel data
+
+    list_parallel_data_response = workflow_api.list_parallel_data()
+    assert list_parallel_data_response.status_code == 200
+    response = list_parallel_data_response.json()
+    assert testing_env_variables['SAMPLE_PARALLEL_DATA'] in json.dumps(response)
+
+    # Download parallel data
+    body = {'parallel_data_name': testing_env_variables['SAMPLE_PARALLEL_DATA']}
+    download_parallel_data_response = workflow_api.download_parallel_data(body)
+    assert download_parallel_data_response.status_code == 200
+
+    response = download_parallel_data_response.json()
+    assert "larger than Earth" in json.dumps(response)
+
+    # Delete parallel data is done in parallel_data fixture
+    
+
+def test_terminology(workflow_api, testing_env_variables, terminology):
+    workflow_api = workflow_api()
+
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    
+    # Create terminology is done in terminology fixture
+
+    # List terminology
+    list_terminologies_response = workflow_api.list_terminologies()
+    assert list_terminologies_response.status_code == 200
+    response = list_terminologies_response.json()
+    assert testing_env_variables['SAMPLE_TERMINOLOGY'] in json.dumps(response)
+
+    # Get terminology
+    body = {'terminology_name': testing_env_variables['SAMPLE_TERMINOLOGY']}
+    get_terminology_response = workflow_api.get_terminology(body)
+    assert get_terminology_response.status_code == 200
+    response = get_terminology_response.json()
+    assert testing_env_variables['SAMPLE_TERMINOLOGY'] == response['TerminologyProperties']['Name']
+
+    # Download terminology
+    body = {'terminology_name': testing_env_variables['SAMPLE_TERMINOLOGY']}
+    download_terminology_response = workflow_api.download_terminology(body)
+    assert download_terminology_response.status_code == 200
+
+    response = download_terminology_response.json()
+    assert "STEEN" in json.dumps(response)
+
+    # Delete parallel data is done in terminology fixture
+    
+
+
+
+    

--- a/test/e2e/test_translate_proxy.py
+++ b/test/e2e/test_translate_proxy.py
@@ -22,8 +22,6 @@ import json
 
 def test_parallel_data(workflow_api, testing_env_variables, parallel_data):
     workflow_api = workflow_api()
-
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     
     # Create parallel data is done in parallel_data fixture
 
@@ -47,7 +45,6 @@ def test_parallel_data(workflow_api, testing_env_variables, parallel_data):
 
 def test_terminology(workflow_api, testing_env_variables, terminology):
     workflow_api = workflow_api()
-
     
     # Create terminology is done in terminology fixture
 
@@ -72,7 +69,7 @@ def test_terminology(workflow_api, testing_env_variables, terminology):
     response = download_terminology_response.json()
     assert "STEEN" in json.dumps(response)
 
-    # Delete parallel data is done in terminology fixture
+    # Delete terminology is done in terminology fixture
     
 
 

--- a/test/test-media/sampleparalleldata
+++ b/test/test-media/sampleparalleldata
@@ -1,0 +1,14 @@
+en,ru
+an international team of astronomers has discovered a trio of hot worlds larger than Earth ,"международная группа астрономов обнаружила тройку горячих миров, больших, чем Земля"
+a collection of stars that stretches across one-third of the sky,"коллекции звезд менее 3% возраста нашей Солнечной системы, которая простирается на треть видимого неба"
+Other observations show that the star has two distant stellar neighbors circling each other far beyond the planets,"Другие наблюдения показывают, что звезда имеет двух дальних звездных соседов, которые кружат друг друга далеко за пределами планет."
+they also tend to have prominent starspots,они также часто имеют видные звездные пятна
+despite the intense heat from their nearby star,несмотря на интенсивную жару от ближайшей им звезды
+Observing starlight passing through the atmospheres of these planets provides an opportunity to study this phase of development ,"Наблюдение за звездным светом, проходящим через атмосферу этих планет, дает возможность изучить эту фазу развития "
+we can infer its chemical composition and the presence of clouds or high-altitude hazes,мы можем сделать вывод о его химическом составе и наличии облаков или высотных дымок
+"This suggests the presence of a debris disk, where rocky asteroid-like bodies collide and grind themselves to dust","Это говорит о наличии диска мусора, где каменистые астероидные тела сталкиваются и измельчают себя до пыли"
+they envision it as a diffuse ring of rock and dust centered about as far from the star as Jupiter is from our Sun,"они представляют собой диффузное кольцо из камня и пыли, сосредоточенное примерно так далеко от звезды, как Юпитер от нашего Солнца"
+Newton’s team determined this star to be a gravitationally bound companion located so far from TOI 451 that its light takes 27 days to get there,"команда Ньютона определила эту звезду как гравитационный компаньон, расположенный так далеко от TOI 451, что ее свет занимает 27 дней, чтобы добраться туда"
+to be brought back to Earth for further analysis,чтобы они были возвращены на Землю для тщательного анализа
+Don't want to have these samples come back from Mars and discover life in them.,"Не хочу, чтобы эти образцы возвращались с Марса и открывали в них жизнь. "
+The requirements that we have for this mission are extraordinarily challenging.,"Требования, которые у нас есть для этой миссии, очень требовательны"


### PR DESCRIPTION
*Issue #, if available:*
Fixes #539
Fixes #570 

*Description of changes:*
## #539
For WebCaptions workflows, handle a TextLimitExceeded error from Polly as a warning for the operator result.  The operator will succeed, with the following result, similar to handling for unsupported languages:

```
{
    ...
    "PollyStatus": "not supported",
    "PollyMessage": "WARNING: Polly.Client.exceptions.TextLengthExceededException",
    ...
}
```

## #570 
Review proxy API calls for Amazon Translate and add some basic e2e CRUD tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
