### PR TITLE
Revert the change to remove TestStack from expected_resources 

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -72,7 +72,7 @@ def stack_resources(testing_env_variables):
     for output in outputs:
         resources[output["OutputKey"]] = output["OutputValue"]
 
-    expected_resources = ['WorkflowApiRestID', 'DataplaneBucket', 'WorkflowCustomResourceArn', 
+    expected_resources = ['WorkflowApiRestID', 'DataplaneBucket', 'WorkflowCustomResourceArn', 'TestStack',
                           'MediaInsightsEnginePython38Layer', 'AnalyticsStreamArn', 'DataplaneApiEndpoint',
                           'WorkflowApiEndpoint', 'DataplaneApiRestID', 'OperatorLibraryStack', 'PollyOperation',
                           'ContentModerationOperationImage', 'GenericDataLookupOperation',


### PR DESCRIPTION
*Issue #, if available:*
Fixes #571 

*Description of changes:*
Reverted the change to remove TestStack from expected_resources in the e2e tests.  There is no dependency for e2e, but all tests share the same deployment and TestStack is needed for other test suites.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
