### PR TITLE
Only run parallel data test in supported regions

### DIFF
--- a/test/e2e/test_translate_proxy.py
+++ b/test/e2e/test_translate_proxy.py
@@ -18,8 +18,10 @@
 import urllib3
 import time
 import json
+import pytest
+import os
 
-
+@pytest.mark.skipif(os.environ['MIE_REGION'] not in ["us-west-2", "us-east-1", "eu-west-1"], reason="Parallel Data is not supported in this region")
 def test_parallel_data(workflow_api, testing_env_variables, parallel_data):
     workflow_api = workflow_api()
     


### PR DESCRIPTION
*Issue #, if available:*

Closes #592
Closes #585

*Description of changes:*

Only run the parallel data proxy API test if the test is running in a region where it is supported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
