### PR TITLE
fix(workflow-scheduler): fix paging inside list_workflow_executions_by_status

### DIFF
--- a/source/workflow/app.py
+++ b/source/workflow/app.py
@@ -95,7 +95,19 @@ def list_workflow_executions_by_status(Status):
 
     workflow_executions = response['Items']
     while 'LastEvaluatedKey' in response:
-        response = table.query(ExclusiveStartKey=response['LastEvaluatedKey'])
+        response = table.query(
+            IndexName='WorkflowExecutionStatus',
+            ExpressionAttributeNames={
+                '#workflow_status': "Status",
+                '#workflow_name': "Name"
+            },
+            ExpressionAttributeValues={
+                ':workflow_status': Status
+            },
+            KeyConditionExpression='#workflow_status = :workflow_status',
+            ProjectionExpression = projection_expression,
+            ExclusiveStartKey=response['LastEvaluatedKey']
+        )
         workflow_executions.extend(response['Items'])
 
     return workflow_executions


### PR DESCRIPTION
*Issue #, if available:*
[607](https://github.com/awslabs/aws-media-insights-engine/issues/607)

*Description of changes:*
Correcting the paging logic for list_workflow_executions_by_status(Status). The current implementation does not pass the proper parameters and as such when paging is needed the following exceptions is thrown: `ClientError: An error occurred (ValidationException) when calling the Query operation: Either the KeyConditions or KeyConditionExpression parameter must be specified in the request.` This is a required change if we want to support running multiple workflows that require paging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
